### PR TITLE
fix: Reset ticket details state when navigating between tickets

### DIFF
--- a/src/app/tickets/[id]/page.tsx
+++ b/src/app/tickets/[id]/page.tsx
@@ -18,6 +18,13 @@ export default function TicketDetailPage() {
   const [comments, setComments] = useState<TicketComment[]>([]);
   const [loading, setLoading] = useState(true);
 
+  // Reset state when navigating to a different ticket
+  useEffect(() => {
+    setTicket(null);
+    setComments([]);
+    setLoading(true);
+  }, [ticketId]);
+
   useEffect(() => {
     if (status === 'unauthenticated') {
       router.push('/login');
@@ -152,6 +159,7 @@ export default function TicketDetailPage() {
   return (
     <MainLayout>
       <TicketDetail
+        key={ticketId}
         ticket={ticket}
         comments={comments}
         onAddComment={handleAddComment}


### PR DESCRIPTION
When navigating from one ticket to another, the details panel was showing stale data from the previous ticket because state wasn't being reset on ticketId change. This fix:

1. Adds useEffect to reset ticket, comments, and loading state when ticketId changes, ensuring the loading spinner shows immediately 
2. Adds key prop to TicketDetail component to reset internal state (like comment textarea) when switching tickets

Fixes #139