### PR TITLE
fix: Add key prop to React.Fragment in TicketList

### DIFF
--- a/src/components/tickets/TicketList.tsx
+++ b/src/components/tickets/TicketList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 import Link from 'next/link';
 import { format } from 'date-fns';
 import { Filter, ChevronDown, ChevronUp, Play } from 'lucide-react';
@@ -226,9 +226,9 @@ export default function TicketList({ tickets, title }: TicketListProps) {
           </thead>
           <tbody>
             {Object.entries(groupedTickets).map(([groupName, groupTickets]) => (
-              <>
+              <React.Fragment key={groupName}>
                 {groupBy === 'assignee' && (
-                  <tr key={`group-${groupName}`}>
+                  <tr>
                     <td
                       colSpan={8}
                       className="px-4 py-2 text-sm font-medium"
@@ -293,7 +293,7 @@ export default function TicketList({ tickets, title }: TicketListProps) {
                     </td>
                   </tr>
                 ))}
-              </>
+              </React.Fragment>
             ))}
           </tbody>
         </table>


### PR DESCRIPTION
## Summary
- Fixes React warning "Each child in a list should have a unique key prop" in TicketList component
- Changed shorthand fragment `<>` to `<React.Fragment key={groupName}>` when mapping over grouped tickets

## Test plan
- [ ] Run `npm run dev` and view tickets list
- [ ] Open browser console and verify no React key warnings appear
- [ ] Confirm ticket list renders correctly with grouping enabled

Fixes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)