### PR TITLE
fix: Add project filter to tickets page (#189)

### DIFF
--- a/src/app/tickets/page.tsx
+++ b/src/app/tickets/page.tsx
@@ -15,6 +15,7 @@ interface Filters {
   priority: TicketPriority | '';
   assignee: string;
   requester: string;
+  project: string;
 }
 
 const viewTitles: Record<string, string> = {
@@ -50,6 +51,7 @@ function TicketsPageContent() {
     priority: '',
     assignee: '',
     requester: '',
+    project: '',
   });
 
   useEffect(() => {
@@ -137,6 +139,7 @@ function TicketsPageContent() {
   const filterOptions = useMemo(() => {
     const assignees = new Set<string>();
     const requesters = new Set<string>();
+    const projects = new Set<string>();
 
     tickets.forEach((ticket) => {
       if (ticket.assignee?.displayName) {
@@ -145,11 +148,15 @@ function TicketsPageContent() {
       if (ticket.requester?.displayName) {
         requesters.add(ticket.requester.displayName);
       }
+      if (ticket.project) {
+        projects.add(ticket.project);
+      }
     });
 
     return {
       assignees: Array.from(assignees).sort(),
       requesters: Array.from(requesters).sort(),
+      projects: Array.from(projects).sort(),
     };
   }, [tickets]);
 
@@ -160,12 +167,13 @@ function TicketsPageContent() {
       if (filters.priority && ticket.priority !== filters.priority) return false;
       if (filters.assignee && ticket.assignee?.displayName !== filters.assignee) return false;
       if (filters.requester && ticket.requester.displayName !== filters.requester) return false;
+      if (filters.project && ticket.project !== filters.project) return false;
       return true;
     });
   }, [tickets, filters]);
 
   const clearFilters = () => {
-    setFilters({ status: '', priority: '', assignee: '', requester: '' });
+    setFilters({ status: '', priority: '', assignee: '', requester: '', project: '' });
   };
 
   // Update URL when display mode changes to preserve view on navigation
@@ -184,7 +192,7 @@ function TicketsPageContent() {
   );
 
   const hasActiveFilters =
-    filters.status || filters.priority || filters.assignee || filters.requester;
+    filters.status || filters.priority || filters.assignee || filters.requester || filters.project;
 
   if (status === 'loading' || loading) {
     return (
@@ -271,6 +279,19 @@ function TicketsPageContent() {
                 {filterOptions.requesters.map((requester) => (
                   <option key={requester} value={requester}>
                     {requester}
+                  </option>
+                ))}
+              </select>
+
+              <select
+                value={filters.project}
+                onChange={(e) => setFilters({ ...filters, project: e.target.value })}
+                className="input text-sm"
+              >
+                <option value="">All Projects</option>
+                {filterOptions.projects.map((project) => (
+                  <option key={project} value={project}>
+                    {project}
                   </option>
                 ))}
               </select>


### PR DESCRIPTION
## Summary
- Added a **Project** dropdown filter to the tickets page
- Users can now filter tickets by specific projects within their organization
- Helps users focus on tasks from a particular project

## Changes
- Added `project` field to Filters interface
- Added project to filterOptions (auto-populated from ticket data)
- Added project filtering logic to filteredTickets
- Added "All Projects" dropdown to the filters toolbar

## How It Works
When viewing the tickets page:
1. All tickets from all projects are fetched
2. Users can use the new "All Projects" dropdown to filter by a specific project
3. The filter works in combination with other filters (status, priority, assignee, requester)

## Test Plan
- [x] Navigate to Tickets page
- [x] Verify "All Projects" dropdown appears in filters
- [x] Select a project and verify only tickets from that project are shown
- [x] Clear filters and verify all tickets reappear

Fixes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)