### PR TITLE
feat: Set dev server to always run on port 3102

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --port 3102",
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary
- Changed `npm run dev` to always use port 3102 (`next dev --port 3102`)

<img width="1323" height="644" alt="image" src="https://github.com/user-attachments/assets/f05680f7-4399-4b52-bf66-52ec3190ff73" />


## Test plan
- [x] Run `npm run dev` and confirm server starts on http://localhost:3102

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)