### PR TITLE
feat: Calculate actual average response time from comment data

### DIFF
--- a/src/app/api/devops/team/route.ts
+++ b/src/app/api/devops/team/route.ts
@@ -324,8 +324,6 @@ async function getFirstResponseTimeMs(
       if (requesterEmail && authorEmail === requesterEmail) continue;
 
       const responseTimeMs = comment.createdAt.getTime() - ticket.createdAt.getTime();
-      if (responseTimeMs <= 0) continue;
-
       const assigneeEmail = ticket.assignee?.email?.toLowerCase();
       if (!assigneeEmail) return null;
 


### PR DESCRIPTION
## Summary
- Replaced workload-based estimate with actual first-response time calculated from work item comments
- Fetches comments for tickets from the last 30 days, finds first internal (non-requester) response
- Parallelized comment fetching in batches of 10 using `Promise.allSettled`
- Added 5-minute TTL cache to avoid re-fetching on repeated page loads
- Falls back to workload-based estimate when no comment data is available


<img width="1876" height="904" alt="image" src="https://github.com/user-attachments/assets/fea2957a-73c6-4d69-b3a4-9c1754ae2f2d" />


## Test plan
- [x] Navigate to the team page and verify avgResponseTime shows actual values (e.g., "2h", "1d", "< 1h")
- [x] Verify members with no recent tickets show fallback estimates
- [x] Reload page within 5 minutes and confirm faster load (cached)

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)