### PR TITLE
fix: Guard Live Dashboard API calls until organization is loaded

### DIFF
--- a/src/app/reporting/page.tsx
+++ b/src/app/reporting/page.tsx
@@ -62,8 +62,12 @@ export default function LiveDashboardPage() {
   }, [status, router]);
 
   const fetchData = useCallback(async () => {
-    if (!session?.accessToken || !hasOrganization) return;
+    if (!session?.accessToken || !hasOrganization) {
+      setLoading(false);
+      return;
+    }
 
+    setLoading(true);
     try {
       // Fetch stats
       const statsResponse = await devOpsGet('/api/devops/stats');


### PR DESCRIPTION
## Summary
- Fixed race condition where the Live Dashboard (`/reporting`) made API calls before the selected organization finished loading, causing persistent 400 errors
- Added `hasOrganization` guard to `fetchData`, useEffect triggers, and auto-refresh interval in `src/app/reporting/page.tsx`
- Matches the existing pattern already used in `NewTicketDialog` component

<img width="1913" height="884" alt="image" src="https://github.com/user-attachments/assets/70214911-7c53-4b9a-9348-1809e688fd66" />
<img width="1906" height="850" alt="image" src="https://github.com/user-attachments/assets/a45d44b5-130f-419b-85fc-24c59117f46a" />



## Root Cause
The reporting page used `useDevOpsApi()` but only guarded API calls on `session?.accessToken`. When the page loaded, the session was available before `selectedOrganization` finished loading from `/api/devops/accounts`. This caused `devOpsGet()` to throw "No organization selected", which was silently caught — and since `selectedOrganization` wasn't in the useEffect dependency array, the page never retried.

The home page (`src/app/page.tsx`) didn't have this issue because it uses direct `fetch()` calls with `selectedOrganization` explicitly in its useEffect deps.

## Test plan
- [x] Navigate to Live Dashboard — stats, recent tickets, and projects should load correctly
- [x] Verify no 400 errors on `/api/devops/stats` or `/api/devops/tickets` in network tab
- [x] Verify auto-refresh continues to work after initial load
- [x] Verify home dashboard still loads correctly

Fixes #244, Fixes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)