### PR TITLE
fix: Sort projects alphabetically by name

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -43,13 +43,13 @@ export default function ProjectsPage() {
         if (response.ok) {
           const data = await response.json();
           setProjects(
-            (data.projects || []).map(
-              (p: ProjectWithSLA & { createdAt: string; updatedAt: string }) => ({
+            (data.projects || [])
+              .map((p: ProjectWithSLA & { createdAt: string; updatedAt: string }) => ({
                 ...p,
                 createdAt: new Date(p.createdAt),
                 updatedAt: new Date(p.updatedAt),
-              })
-            )
+              }))
+              .sort((a: ProjectWithSLA, b: ProjectWithSLA) => a.name.localeCompare(b.name))
           );
         }
       } catch (error) {


### PR DESCRIPTION
## Summary
- Sort projects by name using `localeCompare` after fetching from the API on the `/projects` page

<img width="1185" height="907" alt="image" src="https://github.com/user-attachments/assets/f044ea60-226f-4ccc-a2aa-58494d932b45" />


## Test plan
- [x] Navigate to Projects page — projects should be listed in A-Z order
- [x] Verify no other functionality is affected (links, SLA badges, template warnings)

Fixes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)