### PR TITLE
fix: Add time period filter to Team page

### DIFF
--- a/src/app/api/devops/team/route.ts
+++ b/src/app/api/devops/team/route.ts
@@ -164,12 +164,12 @@ export async function GET(request: NextRequest) {
     // Sort by tickets assigned (descending)
     teamMembers.sort((a, b) => b.ticketsAssigned - a.ticketsAssigned);
 
-    // Calculate team stats
+    // Calculate team stats from ALL tickets (unfiltered by time period)
     const stats: TeamStats = {
       totalMembers: teamMembers.length,
-      openTickets: tickets.filter((t) => t.status === 'Open' || t.status === 'New').length,
-      inProgressTickets: tickets.filter((t) => t.status === 'In Progress').length,
-      needsAttention: calculateNeedsAttention(tickets),
+      openTickets: allTickets.filter((t) => t.status === 'Open' || t.status === 'New').length,
+      inProgressTickets: allTickets.filter((t) => t.status === 'In Progress').length,
+      needsAttention: calculateNeedsAttention(allTickets),
     };
 
     return NextResponse.json({ members: teamMembers, stats });

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -10,7 +10,6 @@ import {
   Ticket,
   AlertCircle,
   Clock,
-  TrendingUp,
   Activity,
   ChevronUp,
   ChevronDown,
@@ -257,46 +256,18 @@ export default function TeamPage() {
                 Monitor team performance, workload distribution, and individual KPIs.
               </p>
             </div>
-            <div className="flex items-center gap-2">
-              <select
-                value={timePeriod ?? ''}
-                onChange={(e) => {
-                  const val = e.target.value;
-                  setTimePeriod(val ? Number(val) : null);
-                }}
-                className="input cursor-pointer text-sm"
-              >
-                <option value="1" className="bg-[var(--surface)] text-[var(--text-primary)]">
-                  Today
-                </option>
-                <option value="7" className="bg-[var(--surface)] text-[var(--text-primary)]">
-                  Last 7 days
-                </option>
-                <option value="30" className="bg-[var(--surface)] text-[var(--text-primary)]">
-                  Last 30 days
-                </option>
-                <option value="90" className="bg-[var(--surface)] text-[var(--text-primary)]">
-                  Last 90 days
-                </option>
-                <option value="" className="bg-[var(--surface)] text-[var(--text-primary)]">
-                  All time
-                </option>
-              </select>
-              <button
-                onClick={() => setTicketsOnly(!ticketsOnly)}
-                className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
-                  ticketsOnly
-                    ? 'bg-[var(--primary)] text-white'
-                    : 'bg-[var(--surface)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
-                }`}
-                title={
-                  ticketsOnly ? 'Showing only items tagged "ticket"' : 'Showing all work items'
-                }
-              >
-                <Tag size={14} />
-                Tickets Only
-              </button>
-            </div>
+            <button
+              onClick={() => setTicketsOnly(!ticketsOnly)}
+              className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                ticketsOnly
+                  ? 'bg-[var(--primary)] text-white'
+                  : 'bg-[var(--surface)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
+              }`}
+              title={ticketsOnly ? 'Showing only items tagged "ticket"' : 'Showing all work items'}
+            >
+              <Tag size={14} />
+              Tickets Only
+            </button>
           </div>
         </div>
 
@@ -402,17 +373,40 @@ export default function TeamPage() {
         {/* Team Members Table */}
         <div className="card">
           <div className="border-b p-4" style={{ borderColor: 'var(--border)' }}>
-            <h2 className="text-lg font-semibold" style={{ color: 'var(--text-primary)' }}>
-              Team Members
-            </h2>
-            <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
-              Individual performance metrics and workload
-              {timePeriod === 1
-                ? ' — today'
-                : timePeriod
-                  ? ` — last ${timePeriod} days`
-                  : ' — all time'}
-            </p>
+            <div className="flex items-center justify-between">
+              <div>
+                <h2 className="text-lg font-semibold" style={{ color: 'var(--text-primary)' }}>
+                  Team Members
+                </h2>
+                <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
+                  Individual performance metrics and workload
+                </p>
+              </div>
+              <select
+                value={timePeriod ?? ''}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  setTimePeriod(val ? Number(val) : null);
+                }}
+                className="input cursor-pointer text-sm"
+              >
+                <option value="1" className="bg-[var(--surface)] text-[var(--text-primary)]">
+                  Today
+                </option>
+                <option value="7" className="bg-[var(--surface)] text-[var(--text-primary)]">
+                  Last 7 days
+                </option>
+                <option value="30" className="bg-[var(--surface)] text-[var(--text-primary)]">
+                  Last 30 days
+                </option>
+                <option value="90" className="bg-[var(--surface)] text-[var(--text-primary)]">
+                  Last 90 days
+                </option>
+                <option value="" className="bg-[var(--surface)] text-[var(--text-primary)]">
+                  All time
+                </option>
+              </select>
+            </div>
           </div>
 
           {loading ? (
@@ -484,7 +478,7 @@ export default function TeamPage() {
                       className="hidden cursor-pointer px-4 py-3 text-center text-xs font-medium tracking-wider uppercase hover:bg-[var(--surface-hover)] md:table-cell"
                       onClick={() => handleSort('weeklyResolved')}
                     >
-                      Weekly Resolved
+                      Resolved
                       <SortIcon column="weeklyResolved" />
                     </th>
                     <th
@@ -575,7 +569,6 @@ export default function TeamPage() {
                         </td>
                         <td className="hidden px-4 py-4 text-center md:table-cell">
                           <div className="flex items-center justify-center gap-2">
-                            <TrendingUp size={16} style={{ color: 'var(--status-resolved)' }} />
                             <span style={{ color: 'var(--text-primary)' }}>
                               {member.weeklyResolutions}
                             </span>


### PR DESCRIPTION
## Summary
- Adds a time period dropdown filter (Today, Last 7 days, Last 30 days, Last 90 days, All time) to the Team Members section
- API route accepts a `days` query parameter to filter tickets by date range
- Stats cards and Team Activity remain unfiltered (all-time data)
- Defaults to Last 30 days
- Renames "Weekly Resolved" column to "Resolved"
- Fixes pre-existing bug where ticketsOnly toggle had no effect on the API

<img width="1131" height="549" alt="image" src="https://github.com/user-attachments/assets/f3fe02d6-8421-4d2e-a945-de19d3703cce" />

Closes #275
Closes #281
Closes #286

## Test plan
- [x] Navigate to /team and verify the time period dropdown appears in the Team Members section header
- [x] Switch between Today/7/30/90 days and All time — only Team Members metrics should change
- [x] Verify stats cards (Team Members, Open Tickets, In Progress, Needs Attention) remain unchanged when switching time period
- [x] Verify Team Activity chart remains unchanged when switching time period
- [x] Verify "Tickets Only" toggle still works alongside the time period filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)