### PR TITLE
fix: Monthly Checkpoint empty dropdown and project ordering

### DIFF
--- a/src/app/monthly-checkpoint/page.tsx
+++ b/src/app/monthly-checkpoint/page.tsx
@@ -26,7 +26,7 @@ function MonthlyCheckpointContent() {
   const [startDate, setStartDate] = useState<string>('');
   const [endDate, setEndDate] = useState<string>('');
   const [stats, setStats] = useState<MonthlyCheckpointStats | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
   const [isLoadingProjects, setIsLoadingProjects] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showNewTicketModal, setShowNewTicketModal] = useState(false);


### PR DESCRIPTION
## Summary
- Fix empty project dropdown by using `useDevOpsApi` hook to include the required `x-devops-org` header in API calls
- Default to "Select a project..." instead of auto-selecting the first project
- Sort projects alphabetically by name
<img width="1130" height="541" alt="image" src="https://github.com/user-attachments/assets/3e8d03cd-0d17-42ff-8c7a-ee4846577b41" />


Closes #285
Closes #287

## Test plan
- [x] Navigate to /monthly-checkpoint — dropdown should show "Select a project..."
- [x] Open dropdown — projects should be listed alphabetically
- [x] Select a project — KPIs and charts should load correctly
- [x] Verify the checkpoint data API also works (uses the org header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)