### PR TITLE
feat: Add ability to add and remove tags on tickets (#311)

### DIFF
--- a/src/app/api/devops/tickets/[id]/route.ts
+++ b/src/app/api/devops/tickets/[id]/route.ts
@@ -67,7 +67,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     }
 
     const body = await request.json();
-    const { assignee, assignToMe, priority, project, title, description } = body;
+    const { assignee, assignToMe, priority, project, title, description, tags } = body;
 
     const organization = request.headers.get('x-devops-org') || undefined;
     const devopsService = new AzureDevOpsService(session.accessToken, organization);
@@ -88,6 +88,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       priority?: number;
       title?: string;
       description?: string;
+      tags?: string[];
     } = {};
 
     if (assignToMe) {
@@ -109,6 +110,10 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 
     if (description !== undefined) {
       updates.description = description;
+    }
+
+    if (tags !== undefined && Array.isArray(tags)) {
+      updates.tags = tags.map((t: string) => t.trim()).filter(Boolean);
     }
 
     // Update the work item

--- a/src/app/api/devops/tickets/[id]/route.ts
+++ b/src/app/api/devops/tickets/[id]/route.ts
@@ -113,7 +113,20 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     }
 
     if (tags !== undefined && Array.isArray(tags)) {
-      updates.tags = tags.map((t: string) => t.trim()).filter(Boolean);
+      // Validate each element is a string
+      if (!tags.every((t: unknown) => typeof t === 'string')) {
+        return NextResponse.json({ error: 'All tags must be strings' }, { status: 400 });
+      }
+      // Reject tags containing semicolons (DevOps delimiter)
+      const cleanTags = (tags as string[]).map((t) => t.trim()).filter(Boolean);
+      if (cleanTags.some((t) => t.includes(';'))) {
+        return NextResponse.json({ error: 'Tags cannot contain semicolons' }, { status: 400 });
+      }
+      // Ensure "ticket" tag is always preserved
+      if (!cleanTags.some((t) => t.toLowerCase() === 'ticket')) {
+        cleanTags.unshift('ticket');
+      }
+      updates.tags = cleanTags;
     }
 
     // Update the work item

--- a/src/app/tickets/[id]/page.tsx
+++ b/src/app/tickets/[id]/page.tsx
@@ -220,6 +220,22 @@ export default function TicketDetailPage() {
     }
   };
 
+  const handleTagsChange = async (tags: string[]) => {
+    if (!ticket) return;
+    try {
+      const response = await fetch(`/api/devops/tickets/${ticketId}`, {
+        method: 'PATCH',
+        headers: orgHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({ tags, project: ticket.project }),
+      });
+      if (response.ok) {
+        await fetchTicket();
+      }
+    } catch (error) {
+      console.error('Failed to update tags:', error);
+    }
+  };
+
   const handleUploadAttachment = async (file: File): Promise<Attachment> => {
     const formData = new FormData();
     formData.append('file', file);
@@ -265,6 +281,7 @@ export default function TicketDetailPage() {
         onAssigneeChange={handleAssigneeChange}
         onPriorityChange={handlePriorityChange}
         onTypeChange={handleTypeChange}
+        onTagsChange={handleTagsChange}
         onDescriptionChange={handleDescriptionChange}
         onUploadAttachment={handleUploadAttachment}
         onRefreshTicket={fetchTicket}

--- a/src/app/tickets/[id]/page.tsx
+++ b/src/app/tickets/[id]/page.tsx
@@ -222,18 +222,16 @@ export default function TicketDetailPage() {
 
   const handleTagsChange = async (tags: string[]) => {
     if (!ticket) return;
-    try {
-      const response = await fetch(`/api/devops/tickets/${ticketId}`, {
-        method: 'PATCH',
-        headers: orgHeaders({ 'Content-Type': 'application/json' }),
-        body: JSON.stringify({ tags, project: ticket.project }),
-      });
-      if (response.ok) {
-        await fetchTicket();
-      }
-    } catch (error) {
-      console.error('Failed to update tags:', error);
+    const response = await fetch(`/api/devops/tickets/${ticketId}`, {
+      method: 'PATCH',
+      headers: orgHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({ tags, project: ticket.project }),
+    });
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      throw new Error(data.error || 'Failed to update tags');
     }
+    await fetchTicket();
   };
 
   const handleUploadAttachment = async (file: File): Promise<Attachment> => {

--- a/src/app/tickets/page.tsx
+++ b/src/app/tickets/page.tsx
@@ -207,10 +207,12 @@ function TicketsPageContent() {
         },
         body: JSON.stringify({ tags, project: ticket.project }),
       });
-      if (response.ok) {
-        setTickets((prev) => prev.map((t) => (t.id === workItemId ? { ...t, tags } : t)));
-        setSelectedTicket((prev) => (prev && prev.id === workItemId ? { ...prev, tags } : prev));
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed to update tags');
       }
+      setTickets((prev) => prev.map((t) => (t.id === workItemId ? { ...t, tags } : t)));
+      setSelectedTicket((prev) => (prev && prev.id === workItemId ? { ...prev, tags } : prev));
     },
     [tickets, selectedOrganization]
   );

--- a/src/app/tickets/page.tsx
+++ b/src/app/tickets/page.tsx
@@ -195,6 +195,26 @@ function TicketsPageContent() {
     }
   }, []);
 
+  const handleDialogTagsChange = useCallback(
+    async (workItemId: number, tags: string[]) => {
+      const ticket = tickets.find((t) => t.id === workItemId);
+      if (!ticket || !selectedOrganization) return;
+      const response = await fetch(`/api/devops/tickets/${workItemId}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-devops-org': selectedOrganization.accountName,
+        },
+        body: JSON.stringify({ tags, project: ticket.project }),
+      });
+      if (response.ok) {
+        setTickets((prev) => prev.map((t) => (t.id === workItemId ? { ...t, tags } : t)));
+        setSelectedTicket((prev) => (prev && prev.id === workItemId ? { ...prev, tags } : prev));
+      }
+    },
+    [tickets, selectedOrganization]
+  );
+
   const handleWorkItemUpdate = useCallback(
     async (workItemId: number, updates: { title?: string; description?: string }) => {
       const ticket = tickets.find((t) => t.id === workItemId);
@@ -280,6 +300,7 @@ function TicketsPageContent() {
           onClose={() => setSelectedTicket(null)}
           onStateChange={handleDialogStateChange}
           onTypeChange={handleDialogTypeChange}
+          onTagsChange={handleDialogTagsChange}
           onUpdate={handleWorkItemUpdate}
         />
 

--- a/src/components/tickets/TicketDetail.tsx
+++ b/src/components/tickets/TicketDetail.tsx
@@ -17,6 +17,8 @@ import {
   Info,
   X,
   Download,
+  Plus,
+  Tag,
 } from 'lucide-react';
 import Link from 'next/link';
 import type {
@@ -57,6 +59,7 @@ interface TicketDetailProps {
   onAssigneeChange?: (assigneeId: string | null) => Promise<void>;
   onPriorityChange?: (priority: number) => Promise<void>;
   onTypeChange?: (type: string) => Promise<void>;
+  onTagsChange?: (tags: string[]) => Promise<void>;
   onDescriptionChange?: (description: string) => Promise<void>;
   onUploadAttachment?: (file: File) => Promise<Attachment>;
   onRefreshTicket?: () => Promise<void>;
@@ -79,6 +82,7 @@ export default function TicketDetail({
   onAssigneeChange,
   onPriorityChange,
   onTypeChange,
+  onTagsChange,
   onDescriptionChange,
   onUploadAttachment,
   onRefreshTicket,
@@ -129,6 +133,40 @@ export default function TicketDetail({
   const [isEditingDescription, setIsEditingDescription] = useState(false);
   const [isSavingDescription, setIsSavingDescription] = useState(false);
   const descriptionRef = useRef<HTMLDivElement>(null);
+
+  // Tag editing state
+  const [newTagInput, setNewTagInput] = useState('');
+  const [isAddingTag, setIsAddingTag] = useState(false);
+  const [isSavingTags, setIsSavingTags] = useState(false);
+
+  const handleAddTag = async () => {
+    const tag = newTagInput.trim();
+    if (!tag || !onTagsChange || isSavingTags) return;
+    if (ticket.tags.includes(tag)) {
+      setNewTagInput('');
+      setIsAddingTag(false);
+      return;
+    }
+    setIsSavingTags(true);
+    try {
+      await onTagsChange([...ticket.tags, tag]);
+      setNewTagInput('');
+      setIsAddingTag(false);
+    } finally {
+      setIsSavingTags(false);
+    }
+  };
+
+  const handleRemoveTag = async (tagToRemove: string) => {
+    if (!onTagsChange || isSavingTags) return;
+    if (tagToRemove.toLowerCase() === 'ticket') return;
+    setIsSavingTags(true);
+    try {
+      await onTagsChange(ticket.tags.filter((t) => t !== tagToRemove));
+    } finally {
+      setIsSavingTags(false);
+    }
+  };
 
   // Attachment state
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
@@ -1220,24 +1258,86 @@ export default function TicketDetail({
             {/* Tags */}
             <div>
               <label
-                className="mb-1 block text-xs uppercase"
+                className="mb-1 flex items-center gap-1 text-xs uppercase"
                 style={{ color: 'var(--text-muted)' }}
               >
+                <Tag size={12} />
                 Tags
               </label>
               <div className="flex flex-wrap gap-1">
                 {ticket.tags.map((tag) => (
                   <span
                     key={tag}
-                    className="rounded px-2 py-0.5 text-xs"
+                    className="flex items-center gap-1 rounded px-2 py-0.5 text-xs"
                     style={{
                       backgroundColor: 'var(--surface-hover)',
                       color: 'var(--text-secondary)',
                     }}
                   >
                     {tag}
+                    {onTagsChange && tag.toLowerCase() !== 'ticket' && (
+                      <button
+                        onClick={() => handleRemoveTag(tag)}
+                        disabled={isSavingTags}
+                        className="ml-0.5 rounded-full transition-colors hover:bg-[var(--surface)]"
+                        style={{ color: 'var(--text-muted)', cursor: 'pointer' }}
+                        title={`Remove tag "${tag}"`}
+                      >
+                        <X size={10} />
+                      </button>
+                    )}
                   </span>
                 ))}
+                {onTagsChange && (
+                  <>
+                    {isAddingTag ? (
+                      <div className="flex items-center gap-1">
+                        <input
+                          type="text"
+                          value={newTagInput}
+                          onChange={(e) => setNewTagInput(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') handleAddTag();
+                            if (e.key === 'Escape') {
+                              setIsAddingTag(false);
+                              setNewTagInput('');
+                            }
+                          }}
+                          placeholder="New tag..."
+                          autoFocus
+                          disabled={isSavingTags}
+                          className="rounded border px-2 py-0.5 text-xs"
+                          style={{
+                            backgroundColor: 'var(--surface)',
+                            borderColor: 'var(--border)',
+                            color: 'var(--text-primary)',
+                            width: '100px',
+                          }}
+                        />
+                        {isSavingTags && (
+                          <Loader2
+                            size={12}
+                            className="animate-spin"
+                            style={{ color: 'var(--text-muted)' }}
+                          />
+                        )}
+                      </div>
+                    ) : (
+                      <button
+                        onClick={() => setIsAddingTag(true)}
+                        className="flex items-center gap-0.5 rounded px-2 py-0.5 text-xs transition-colors hover:bg-[var(--surface-hover)]"
+                        style={{
+                          color: 'var(--primary)',
+                          cursor: 'pointer',
+                          border: '1px dashed var(--border)',
+                        }}
+                      >
+                        <Plus size={10} />
+                        Add
+                      </button>
+                    )}
+                  </>
+                )}
               </div>
             </div>
 

--- a/src/components/tickets/TicketDetail.tsx
+++ b/src/components/tickets/TicketDetail.tsx
@@ -1277,11 +1277,13 @@ export default function TicketDetail({
                     {tag}
                     {onTagsChange && tag.toLowerCase() !== 'ticket' && (
                       <button
+                        type="button"
                         onClick={() => handleRemoveTag(tag)}
                         disabled={isSavingTags}
                         className="ml-0.5 rounded-full transition-colors hover:bg-[var(--surface)]"
                         style={{ color: 'var(--text-muted)', cursor: 'pointer' }}
                         title={`Remove tag "${tag}"`}
+                        aria-label={`Remove tag ${tag}`}
                       >
                         <X size={10} />
                       </button>

--- a/src/components/tickets/WorkItemDetailDialog.tsx
+++ b/src/components/tickets/WorkItemDetailDialog.tsx
@@ -19,6 +19,7 @@ interface WorkItemDetailDialogProps {
   onAssigneeChange?: (workItemId: number, assigneeId: string | null) => Promise<void>;
   onPriorityChange?: (workItemId: number, priority: number) => Promise<void>;
   onTypeChange?: (workItemId: number, type: string) => Promise<void>;
+  onTagsChange?: (workItemId: number, tags: string[]) => Promise<void>;
   onUpdate?: (
     workItemId: number,
     updates: { title?: string; description?: string }
@@ -33,6 +34,7 @@ export default function WorkItemDetailDialog({
   onAssigneeChange,
   onPriorityChange,
   onTypeChange,
+  onTagsChange,
   onUpdate,
 }: WorkItemDetailDialogProps) {
   const router = useRouter();
@@ -279,6 +281,10 @@ export default function WorkItemDetailDialog({
         canEditAssignee={!!onAssigneeChange}
         canEditPriority={!!onPriorityChange}
         canEditType={!!onTypeChange}
+        canEditTags={!!onTagsChange}
+        onTagsChange={
+          onTagsChange ? (tags: string[]) => onTagsChange(workItem.id, tags) : undefined
+        }
       />
     </div>
   );

--- a/src/components/tickets/WorkItemDetailSidebar.tsx
+++ b/src/components/tickets/WorkItemDetailSidebar.tsx
@@ -421,11 +421,13 @@ export default function WorkItemDetailSidebar({
               {tag}
               {tagsEditable && tag.toLowerCase() !== 'ticket' && (
                 <button
+                  type="button"
                   onClick={() => handleRemoveTag(tag)}
                   disabled={isSavingTags}
                   className="ml-0.5 rounded-full transition-colors hover:bg-[var(--surface)]"
                   style={{ color: 'var(--text-muted)', cursor: 'pointer' }}
                   title={`Remove tag "${tag}"`}
+                  aria-label={`Remove tag ${tag}`}
                 >
                   <X size={10} />
                 </button>

--- a/src/components/tickets/WorkItemDetailSidebar.tsx
+++ b/src/components/tickets/WorkItemDetailSidebar.tsx
@@ -9,13 +9,16 @@ import {
   Loader2,
   User as UserIcon,
   Timer,
+  X,
+  Plus,
+  Tag,
 } from 'lucide-react';
 import type { WorkItem, TicketPriority, WorkItemType } from '@/types';
 import type { WorkItemActions } from '@/hooks/useWorkItemActions';
 import Avatar from '../common/Avatar';
 import PriorityIndicator from '../common/PriorityIndicator';
 import { useClickOutside } from '@/hooks';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 
 interface WorkItemDetailSidebarProps {
   workItem: WorkItem;
@@ -26,6 +29,8 @@ interface WorkItemDetailSidebarProps {
   canEditAssignee?: boolean;
   canEditPriority?: boolean;
   canEditType?: boolean;
+  canEditTags?: boolean;
+  onTagsChange?: (tags: string[]) => Promise<void>;
 }
 
 const priorityOptions: Array<{ value: number; label: TicketPriority }> = [
@@ -50,7 +55,46 @@ export default function WorkItemDetailSidebar({
   canEditAssignee = true,
   canEditPriority = true,
   canEditType = false,
+  canEditTags = false,
+  onTagsChange,
 }: WorkItemDetailSidebarProps) {
+  const [newTag, setNewTag] = useState('');
+  const [isAddingTag, setIsAddingTag] = useState(false);
+  const [isSavingTags, setIsSavingTags] = useState(false);
+
+  const tagsEditable = canEditTags && !!onTagsChange;
+
+  const handleAddTag = async () => {
+    const tag = newTag.trim();
+    if (!tag || !onTagsChange || isSavingTags) return;
+    const currentTags = workItem.tags || [];
+    if (currentTags.includes(tag)) {
+      setNewTag('');
+      setIsAddingTag(false);
+      return;
+    }
+    setIsSavingTags(true);
+    try {
+      await onTagsChange([...currentTags, tag]);
+      setNewTag('');
+      setIsAddingTag(false);
+    } finally {
+      setIsSavingTags(false);
+    }
+  };
+
+  const handleRemoveTag = async (tagToRemove: string) => {
+    if (!onTagsChange || isSavingTags) return;
+    // Prevent removing the "ticket" tag
+    if (tagToRemove.toLowerCase() === 'ticket') return;
+    const currentTags = workItem.tags || [];
+    setIsSavingTags(true);
+    try {
+      await onTagsChange(currentTags.filter((t) => t !== tagToRemove));
+    } finally {
+      setIsSavingTags(false);
+    }
+  };
   const closeAssigneeDropdown = useCallback(() => {
     actions.setIsAssigneeDropdownOpen(false);
     actions.setAssigneeSearch('');
@@ -356,27 +400,90 @@ export default function WorkItemDetailSidebar({
       )}
 
       {/* Tags */}
-      {workItem.tags && workItem.tags.length > 0 && (
-        <div>
-          <label className="mb-1 block text-xs uppercase" style={{ color: 'var(--text-muted)' }}>
-            Tags
-          </label>
-          <div className="flex flex-wrap gap-1">
-            {workItem.tags.map((tag) => (
-              <span
-                key={tag}
-                className="rounded px-2 py-0.5 text-xs"
-                style={{
-                  backgroundColor: 'var(--surface-hover)',
-                  color: 'var(--text-secondary)',
-                }}
-              >
-                {tag}
-              </span>
-            ))}
-          </div>
+      <div>
+        <label
+          className="mb-1 flex items-center gap-1 text-xs uppercase"
+          style={{ color: 'var(--text-muted)' }}
+        >
+          <Tag size={12} />
+          Tags
+        </label>
+        <div className="flex flex-wrap gap-1">
+          {(workItem.tags || []).map((tag) => (
+            <span
+              key={tag}
+              className="flex items-center gap-1 rounded px-2 py-0.5 text-xs"
+              style={{
+                backgroundColor: 'var(--surface-hover)',
+                color: 'var(--text-secondary)',
+              }}
+            >
+              {tag}
+              {tagsEditable && tag.toLowerCase() !== 'ticket' && (
+                <button
+                  onClick={() => handleRemoveTag(tag)}
+                  disabled={isSavingTags}
+                  className="ml-0.5 rounded-full transition-colors hover:bg-[var(--surface)]"
+                  style={{ color: 'var(--text-muted)', cursor: 'pointer' }}
+                  title={`Remove tag "${tag}"`}
+                >
+                  <X size={10} />
+                </button>
+              )}
+            </span>
+          ))}
+          {tagsEditable && (
+            <>
+              {isAddingTag ? (
+                <div className="flex items-center gap-1">
+                  <input
+                    type="text"
+                    value={newTag}
+                    onChange={(e) => setNewTag(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') handleAddTag();
+                      if (e.key === 'Escape') {
+                        setIsAddingTag(false);
+                        setNewTag('');
+                      }
+                    }}
+                    placeholder="New tag..."
+                    autoFocus
+                    disabled={isSavingTags}
+                    className="rounded border px-2 py-0.5 text-xs"
+                    style={{
+                      backgroundColor: 'var(--surface)',
+                      borderColor: 'var(--border)',
+                      color: 'var(--text-primary)',
+                      width: '100px',
+                    }}
+                  />
+                  {isSavingTags && (
+                    <Loader2
+                      size={12}
+                      className="animate-spin"
+                      style={{ color: 'var(--text-muted)' }}
+                    />
+                  )}
+                </div>
+              ) : (
+                <button
+                  onClick={() => setIsAddingTag(true)}
+                  className="flex items-center gap-0.5 rounded px-2 py-0.5 text-xs transition-colors hover:bg-[var(--surface-hover)]"
+                  style={{
+                    color: 'var(--primary)',
+                    cursor: 'pointer',
+                    border: '1px dashed var(--border)',
+                  }}
+                >
+                  <Plus size={10} />
+                  Add
+                </button>
+              )}
+            </>
+          )}
         </div>
-      )}
+      </div>
 
       {/* Hours Summary - for work items */}
       {showEffortHours && (workItem.completedWork > 0 || workItem.remainingWork > 0) && (

--- a/src/lib/devops.ts
+++ b/src/lib/devops.ts
@@ -998,9 +998,18 @@ export class AzureDevOpsService {
       priority?: number;
       title?: string;
       description?: string;
+      tags?: string[];
     }
   ): Promise<DevOpsWorkItem> {
     const patchDocument: Array<{ op: string; path: string; value: string | number | null }> = [];
+
+    if (updates.tags !== undefined) {
+      patchDocument.push({
+        op: 'add',
+        path: '/fields/System.Tags',
+        value: updates.tags.join('; '),
+      });
+    }
 
     if (updates.title !== undefined) {
       patchDocument.push({

--- a/src/lib/devops.ts
+++ b/src/lib/devops.ts
@@ -1155,7 +1155,7 @@ export class AzureDevOpsService {
 
     if (updates.tags !== undefined) {
       patchDocument.push({
-        op: 'add',
+        op: 'replace',
         path: '/fields/System.Tags',
         value: updates.tags.join('; '),
       });


### PR DESCRIPTION
## Summary
- Add/remove tags on tickets from both the detail page and the dialog sidebar
- Tags update via Azure DevOps `System.Tags` field through the existing PATCH endpoint
- Protected "ticket" tag cannot be removed (prevents breaking ZapDesk ticket filtering)

## Test plan
- [x] Open a ticket detail page — tags section shows "+ Add" button
- [x] Click "+ Add", type a tag, press Enter — tag is saved to Azure DevOps
- [x] Click X on a tag to remove it — tag is removed
- [x] Verify "ticket" tag has no X button (protected)
- [x] Open a ticket from the list/kanban dialog — same tag editing works
- [x] Verify tags sync back to Azure DevOps work item

## Screenshot
<img width="1852" height="1276" alt="image" src="https://github.com/user-attachments/assets/2e6ce9b7-6cf8-4e09-94ee-0e34dd99e3a5" />

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)