### PR TITLE
feat: Paste images in ticket comments (#308)

### DIFF
--- a/src/app/api/devops/attachments/[id]/route.ts
+++ b/src/app/api/devops/attachments/[id]/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/**
+ * Proxy endpoint to serve Azure DevOps attachment files.
+ * DevOps attachment URLs require authentication, so this route
+ * fetches the file server-side and streams it to the browser.
+ */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.accessToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+    const organization = request.headers.get('x-devops-org') || process.env.AZURE_DEVOPS_ORG || '';
+    const fileName = request.nextUrl.searchParams.get('fileName') || 'attachment';
+
+    const devopsUrl = `https://dev.azure.com/${encodeURIComponent(organization)}/_apis/wit/attachments/${id}?api-version=7.0`;
+
+    const response = await fetch(devopsUrl, {
+      headers: {
+        Authorization: `Bearer ${session.accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: `Failed to fetch attachment: ${response.statusText}` },
+        { status: response.status }
+      );
+    }
+
+    const contentType = response.headers.get('content-type') || 'application/octet-stream';
+    const body = await response.arrayBuffer();
+
+    return new NextResponse(body, {
+      headers: {
+        'Content-Type': contentType,
+        'Content-Disposition': `inline; filename="${fileName}"`,
+        'Cache-Control': 'private, max-age=3600',
+      },
+    });
+  } catch (error) {
+    console.error('Error proxying attachment:', error);
+    return NextResponse.json({ error: 'Failed to fetch attachment' }, { status: 500 });
+  }
+}

--- a/src/app/api/devops/attachments/[id]/route.ts
+++ b/src/app/api/devops/attachments/[id]/route.ts
@@ -4,6 +4,14 @@ import { authOptions } from '@/lib/auth';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
+/** Sanitize filename for Content-Disposition header (strip control chars and quotes). */
+function sanitizeFileName(name: string): string {
+  return name.replace(/["\\\x00-\x1f\x7f]/g, '_').slice(0, 255);
+}
+
+/** Max attachment size to proxy (50MB). */
+const MAX_PROXY_SIZE = 50 * 1024 * 1024;
+
 /**
  * Proxy endpoint to serve Azure DevOps attachment files.
  * DevOps attachment URLs require authentication, so this route
@@ -17,8 +25,14 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     const { id } = await params;
-    const organization = request.headers.get('x-devops-org') || process.env.AZURE_DEVOPS_ORG || '';
-    const fileName = request.nextUrl.searchParams.get('fileName') || 'attachment';
+    // Use org from query param (embedded in img src), fall back to header, then env
+    const organization =
+      request.nextUrl.searchParams.get('org') ||
+      request.headers.get('x-devops-org') ||
+      process.env.AZURE_DEVOPS_ORG ||
+      '';
+    const rawFileName = request.nextUrl.searchParams.get('fileName') || 'attachment';
+    const fileName = sanitizeFileName(rawFileName);
 
     const devopsUrl = `https://dev.azure.com/${encodeURIComponent(organization)}/_apis/wit/attachments/${id}?api-version=7.0`;
 
@@ -35,9 +49,28 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    const contentType = response.headers.get('content-type') || 'application/octet-stream';
-    const body = await response.arrayBuffer();
+    // Check content length to avoid excessive memory usage
+    const contentLength = parseInt(response.headers.get('content-length') || '0', 10);
+    if (contentLength > MAX_PROXY_SIZE) {
+      return NextResponse.json({ error: 'Attachment too large to proxy' }, { status: 413 });
+    }
 
+    const contentType = response.headers.get('content-type') || 'application/octet-stream';
+
+    // Stream the response body if available, otherwise fall back to arrayBuffer
+    if (response.body) {
+      return new NextResponse(response.body, {
+        headers: {
+          'Content-Type': contentType,
+          'Content-Disposition': `inline; filename="${fileName}"`,
+          'Cache-Control': 'private, max-age=3600',
+          ...(contentLength > 0 && { 'Content-Length': String(contentLength) }),
+        },
+      });
+    }
+
+    // Fallback: buffer into memory
+    const body = await response.arrayBuffer();
     return new NextResponse(body, {
       headers: {
         'Content-Type': contentType,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -323,6 +323,15 @@ body {
     color: var(--text-secondary) !important;
   }
 
+  /* Inline images in user content (comments, descriptions) */
+  .user-content img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 0.375rem;
+    margin: 0.5rem 0;
+    border: 1px solid var(--border);
+  }
+
   /* Mention styles */
   .mention {
     background: rgba(34, 197, 94, 0.15);

--- a/src/components/common/MentionInput.tsx
+++ b/src/components/common/MentionInput.tsx
@@ -29,6 +29,7 @@ function escapeAttr(val: string): string {
 /** Validate that a URL is safe (relative or http/https). */
 function isSafeUrl(url: string): boolean {
   if (url.startsWith('/')) return true;
+  if (url.startsWith('data:image/')) return true;
   try {
     const parsed = new URL(url);
     return parsed.protocol === 'http:' || parsed.protocol === 'https:';

--- a/src/components/common/MentionInput.tsx
+++ b/src/components/common/MentionInput.tsx
@@ -1,20 +1,13 @@
 'use client';
 
-import {
-  useState,
-  useEffect,
-  useRef,
-  useCallback,
-  type KeyboardEvent,
-  type ChangeEvent,
-} from 'react';
+import { useState, useEffect, useRef, useCallback, type KeyboardEvent } from 'react';
 import type { User } from '@/types';
 import Avatar from './Avatar';
 
 interface MentionInputProps {
   value: string;
   onChange: (value: string) => void;
-  onPaste?: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void;
+  onPaste?: (e: React.ClipboardEvent<HTMLDivElement>) => void;
   placeholder?: string;
   className?: string;
   disabled?: boolean;
@@ -22,6 +15,45 @@ interface MentionInputProps {
 
 interface MentionUser extends User {
   matchScore?: number;
+}
+
+/** Extract plain text from the contentEditable innerHTML (strips tags except img). */
+function getTextContent(el: HTMLDivElement): string {
+  // Walk child nodes: keep text nodes and img tags, convert <br>/<div> to newlines
+  let text = '';
+  const walk = (node: Node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      text += node.textContent || '';
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+      const tag = (node as HTMLElement).tagName;
+      if (tag === 'IMG') {
+        const src = (node as HTMLImageElement).src;
+        const alt = (node as HTMLImageElement).alt || 'image';
+        text += `<img src="${src}" alt="${alt}" />`;
+      } else if (tag === 'BR') {
+        text += '\n';
+      } else if (tag === 'DIV' || tag === 'P') {
+        if (text.length > 0 && !text.endsWith('\n')) text += '\n';
+        node.childNodes.forEach(walk);
+        return;
+      }
+      node.childNodes.forEach(walk);
+    }
+  };
+  el.childNodes.forEach(walk);
+  return text;
+}
+
+/** Get cursor offset in plain text terms within the contentEditable. */
+function getCursorOffset(el: HTMLDivElement): number {
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0) return 0;
+
+  const range = sel.getRangeAt(0);
+  const preRange = document.createRange();
+  preRange.selectNodeContents(el);
+  preRange.setEnd(range.startContainer, range.startOffset);
+  return preRange.toString().length;
 }
 
 export default function MentionInput({
@@ -40,15 +72,45 @@ export default function MentionInput({
   const [allUsers, setAllUsers] = useState<User[]>([]);
   const [isLoadingUsers, setIsLoadingUsers] = useState(false);
   const [hasLoadedUsers, setHasLoadedUsers] = useState(false);
+  const [isEmpty, setIsEmpty] = useState(true);
 
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const editorRef = useRef<HTMLDivElement>(null);
   const suggestionsRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isInternalUpdate = useRef(false);
 
-  // Fetch users when component mounts or when mention is triggered
+  // Sync external value changes into the editor
+  useEffect(() => {
+    const el = editorRef.current;
+    if (!el || isInternalUpdate.current) {
+      isInternalUpdate.current = false;
+      return;
+    }
+
+    // Only sync if the value has actually changed from what's in the editor
+    const currentText = getTextContent(el);
+    if (currentText !== value) {
+      // Convert value to HTML: preserve img tags, convert newlines to <br>
+      const html = value
+        .replace(/(<img [^>]+>)/g, '\x00$1\x00') // protect img tags
+        .split('\x00')
+        .map((part) => {
+          if (part.startsWith('<img ')) return part;
+          return part
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/\n/g, '<br>');
+        })
+        .join('');
+      el.innerHTML = html || '';
+    }
+    setIsEmpty(!value);
+  }, [value]);
+
+  // Fetch users
   const fetchUsers = useCallback(async () => {
     if (hasLoadedUsers || isLoadingUsers) return;
-
     setIsLoadingUsers(true);
     try {
       const response = await fetch('/api/devops/users');
@@ -64,84 +126,65 @@ export default function MentionInput({
     }
   }, [hasLoadedUsers, isLoadingUsers]);
 
-  // Filter users based on query
+  // Filter users
   const filterUsers = useCallback(
     (query: string): MentionUser[] => {
-      if (!query) {
-        // Return first 8 users when no query
-        return allUsers.slice(0, 8);
-      }
-
+      if (!query) return allUsers.slice(0, 8);
       const lowerQuery = query.toLowerCase();
-      const filtered = allUsers
+      return allUsers
         .map((user) => {
-          const displayNameLower = user.displayName.toLowerCase();
-          const emailLower = (user.email || '').toLowerCase();
-
-          // Calculate match score for better sorting
+          const dn = user.displayName.toLowerCase();
+          const em = (user.email || '').toLowerCase();
           let matchScore = 0;
-          if (displayNameLower.startsWith(lowerQuery)) {
-            matchScore = 100;
-          } else if (displayNameLower.includes(lowerQuery)) {
-            matchScore = 50;
-          } else if (emailLower.startsWith(lowerQuery)) {
-            matchScore = 40;
-          } else if (emailLower.includes(lowerQuery)) {
-            matchScore = 20;
-          }
-
+          if (dn.startsWith(lowerQuery)) matchScore = 100;
+          else if (dn.includes(lowerQuery)) matchScore = 50;
+          else if (em.startsWith(lowerQuery)) matchScore = 40;
+          else if (em.includes(lowerQuery)) matchScore = 20;
           return { ...user, matchScore };
         })
-        .filter((user) => user.matchScore > 0)
+        .filter((u) => u.matchScore > 0)
         .sort((a, b) => (b.matchScore || 0) - (a.matchScore || 0))
         .slice(0, 8);
-
-      return filtered;
     },
     [allUsers]
   );
 
   // Debounced filter
   useEffect(() => {
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current);
-    }
-
+    if (debounceRef.current) clearTimeout(debounceRef.current);
     if (showSuggestions) {
       debounceRef.current = setTimeout(() => {
-        const filtered = filterUsers(mentionQuery);
-        setSuggestions(filtered);
+        setSuggestions(filterUsers(mentionQuery));
         setSelectedIndex(0);
-      }, 100); // 100ms debounce
+      }, 100);
     }
-
     return () => {
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-      }
+      if (debounceRef.current) clearTimeout(debounceRef.current);
     };
   }, [mentionQuery, showSuggestions, filterUsers]);
 
-  // Handle text change
-  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
-    const newValue = e.target.value;
-    const cursorPos = e.target.selectionStart;
+  // Handle input in the contentEditable
+  const handleInput = () => {
+    const el = editorRef.current;
+    if (!el) return;
 
-    onChange(newValue);
+    const text = getTextContent(el);
+    isInternalUpdate.current = true;
+    onChange(text);
+    setIsEmpty(!text.trim());
 
-    // Check if we should show mention suggestions
-    const textBeforeCursor = newValue.slice(0, cursorPos);
+    // Check for mention trigger
+    const cursorPos = getCursorOffset(el);
+    const textBeforeCursor = text.replace(/<img [^>]+>/g, '').slice(0, cursorPos);
     const lastAtIndex = textBeforeCursor.lastIndexOf('@');
 
     if (lastAtIndex !== -1) {
-      // Check if @ is at start or preceded by whitespace
-      const charBeforeAt = lastAtIndex > 0 ? textBeforeCursor[lastAtIndex - 1] : ' ';
-      if (charBeforeAt === ' ' || charBeforeAt === '\n' || lastAtIndex === 0) {
-        const textAfterAt = textBeforeCursor.slice(lastAtIndex + 1);
-        // Only show if there's no space after @ (still typing the mention)
-        if (!textAfterAt.includes(' ') && !textAfterAt.includes('\n')) {
+      const charBefore = lastAtIndex > 0 ? textBeforeCursor[lastAtIndex - 1] : ' ';
+      if (charBefore === ' ' || charBefore === '\n' || lastAtIndex === 0) {
+        const afterAt = textBeforeCursor.slice(lastAtIndex + 1);
+        if (!afterAt.includes(' ') && !afterAt.includes('\n')) {
           setMentionStartIndex(lastAtIndex);
-          setMentionQuery(textAfterAt);
+          setMentionQuery(afterAt);
           setShowSuggestions(true);
           fetchUsers();
           return;
@@ -149,14 +192,13 @@ export default function MentionInput({
       }
     }
 
-    // Hide suggestions if no valid mention context
     setShowSuggestions(false);
     setMentionQuery('');
     setMentionStartIndex(-1);
   };
 
-  // Handle keyboard navigation
-  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+  // Keyboard navigation for mentions
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     if (!showSuggestions) return;
 
     switch (e.key) {
@@ -191,71 +233,117 @@ export default function MentionInput({
     }
   };
 
-  // Select a user from suggestions
+  // Select a mention user
   const selectUser = (user: MentionUser) => {
     if (mentionStartIndex === -1) return;
+    const el = editorRef.current;
+    if (!el) return;
 
-    const textarea = textareaRef.current;
-    if (!textarea) return;
-
-    // Create the mention text - use displayName for readability
     const mentionText = `@${user.displayName} `;
+    const text = getTextContent(el);
+    // Strip img tags for text-position calculation
+    const plainText = text.replace(/<img [^>]+>/g, '');
+    const before = plainText.slice(0, mentionStartIndex);
+    const after = plainText.slice(mentionStartIndex + 1 + mentionQuery.length);
+    const newValue = before + mentionText + after;
 
-    // Replace the @query with the mention
-    const beforeMention = value.slice(0, mentionStartIndex);
-    const afterMention = value.slice(mentionStartIndex + 1 + mentionQuery.length);
-    const newValue = beforeMention + mentionText + afterMention;
+    // Re-insert any img tags that were in the original value
+    const imgTags: string[] = [];
+    text.replace(/<img [^>]+>/g, (match) => {
+      imgTags.push(match);
+      return '';
+    });
+    let finalValue = newValue;
+    for (const img of imgTags) {
+      if (!finalValue.includes(img)) {
+        finalValue = finalValue + '\n' + img;
+      }
+    }
 
-    onChange(newValue);
+    isInternalUpdate.current = false; // Allow sync
+    onChange(finalValue);
 
-    // Close suggestions
     setShowSuggestions(false);
     setMentionQuery('');
     setMentionStartIndex(-1);
 
-    // Set cursor position after the mention
-    const newCursorPos = mentionStartIndex + mentionText.length;
-    requestAnimationFrame(() => {
-      textarea.focus();
-      textarea.setSelectionRange(newCursorPos, newCursorPos);
-    });
+    requestAnimationFrame(() => el.focus());
   };
 
-  // Scroll selected item into view
+  // Handle paste — delegate to parent for image handling
+  const handlePaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
+    // Debug: log clipboard contents
+    console.log('[MentionInput paste]', {
+      filesCount: e.clipboardData?.files?.length,
+      fileTypes: e.clipboardData?.files
+        ? Array.from(e.clipboardData.files).map((f) => f.type)
+        : [],
+      itemsCount: e.clipboardData?.items?.length,
+      itemTypes: e.clipboardData?.items
+        ? Array.from(e.clipboardData.items).map((i) => `${i.kind}:${i.type}`)
+        : [],
+      hasOnPaste: !!onPaste,
+    });
+
+    // Check for images in clipboardData.files (Chrome/Edge screenshots)
+    const hasFileImages =
+      e.clipboardData?.files?.length > 0 &&
+      Array.from(e.clipboardData.files).some((f) => f.type.startsWith('image/'));
+
+    // Also check clipboardData.items (Firefox, some Windows paste scenarios)
+    const hasItemImages =
+      !hasFileImages &&
+      e.clipboardData?.items &&
+      Array.from(e.clipboardData.items).some(
+        (item) => item.kind === 'file' && item.type.startsWith('image/')
+      );
+
+    if ((hasFileImages || hasItemImages) && onPaste) {
+      onPaste(e);
+      return;
+    }
+
+    // For non-image paste, strip HTML formatting and insert as plain text
+    const text = e.clipboardData?.getData('text/plain');
+    if (text) {
+      e.preventDefault();
+      document.execCommand('insertText', false, text);
+    }
+    // If no text and no images, let the browser handle it (e.g. empty paste)
+  };
+
+  // Scroll selected into view
   useEffect(() => {
     if (suggestionsRef.current && showSuggestions) {
-      const selectedEl = suggestionsRef.current.children[selectedIndex] as HTMLElement;
-      if (selectedEl) {
-        selectedEl.scrollIntoView({ block: 'nearest' });
-      }
+      const el = suggestionsRef.current.children[selectedIndex] as HTMLElement;
+      if (el) el.scrollIntoView({ block: 'nearest' });
     }
   }, [selectedIndex, showSuggestions]);
 
-  // Calculate dropdown position
-  const getDropdownPosition = () => {
-    const textarea = textareaRef.current;
-    if (!textarea) return { top: 0, left: 0 };
-
-    // Position above the textarea
-    return {
-      bottom: '100%',
-      left: 0,
-      marginBottom: '4px',
-    };
-  };
-
   return (
     <div className="relative">
-      <textarea
-        ref={textareaRef}
-        value={value}
-        onChange={handleChange}
+      <div
+        ref={editorRef}
+        contentEditable={!disabled}
+        suppressContentEditableWarning
+        onInput={handleInput}
         onKeyDown={handleKeyDown}
-        onPaste={onPaste}
-        placeholder={placeholder}
-        disabled={disabled}
-        className={className}
+        onPaste={handlePaste}
+        className={`${className} user-content`}
+        role="textbox"
+        aria-multiline="true"
+        aria-placeholder={placeholder}
+        style={{ minHeight: '100px', overflowY: 'auto' }}
       />
+      {/* Placeholder overlay */}
+      {isEmpty && (
+        <div
+          className="pointer-events-none absolute top-0 left-0 px-3 py-2 text-sm"
+          style={{ color: 'var(--text-muted)' }}
+        >
+          {placeholder}
+        </div>
+      )}
 
       {/* Mention suggestions dropdown */}
       {showSuggestions && (
@@ -263,7 +351,9 @@ export default function MentionInput({
           ref={suggestionsRef}
           className="absolute z-50 max-h-48 w-64 overflow-auto rounded-md shadow-lg"
           style={{
-            ...getDropdownPosition(),
+            bottom: '100%',
+            left: 0,
+            marginBottom: '4px',
             backgroundColor: 'var(--surface)',
             border: '1px solid var(--border)',
           }}

--- a/src/components/common/MentionInput.tsx
+++ b/src/components/common/MentionInput.tsx
@@ -17,9 +17,34 @@ interface MentionUser extends User {
   matchScore?: number;
 }
 
+/** Escape HTML attribute values to prevent injection. */
+function escapeAttr(val: string): string {
+  return val
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/** Validate that a URL is safe (relative or http/https). */
+function isSafeUrl(url: string): boolean {
+  if (url.startsWith('/')) return true;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/** Sanitize an img tag string — only allow safe src and plain alt. */
+function sanitizeImgTag(src: string, alt: string): string {
+  if (!isSafeUrl(src)) return '';
+  return `<img src="${escapeAttr(src)}" alt="${escapeAttr(alt)}" />`;
+}
+
 /** Extract plain text from the contentEditable innerHTML (strips tags except img). */
 function getTextContent(el: HTMLDivElement): string {
-  // Walk child nodes: keep text nodes and img tags, convert <br>/<div> to newlines
   let text = '';
   const walk = (node: Node) => {
     if (node.nodeType === Node.TEXT_NODE) {
@@ -29,7 +54,8 @@ function getTextContent(el: HTMLDivElement): string {
       if (tag === 'IMG') {
         const src = (node as HTMLImageElement).src;
         const alt = (node as HTMLImageElement).alt || 'image';
-        text += `<img src="${src}" alt="${alt}" />`;
+        const sanitized = sanitizeImgTag(src, alt);
+        if (sanitized) text += sanitized;
       } else if (tag === 'BR') {
         text += '\n';
       } else if (tag === 'DIV' || tag === 'P') {
@@ -54,6 +80,48 @@ function getCursorOffset(el: HTMLDivElement): number {
   preRange.selectNodeContents(el);
   preRange.setEnd(range.startContainer, range.startOffset);
   return preRange.toString().length;
+}
+
+/**
+ * Convert a value string to safe HTML for the contentEditable.
+ * Only whitelisted <img> tags (with safe src) are preserved; everything else is escaped.
+ */
+function valueToSafeHtml(value: string): string {
+  // Split on img tags, validate each one, escape everything else
+  const IMG_REGEX = /<img\s+src="([^"]*?)"\s+alt="([^"]*?)"\s*\/?>/g;
+  let lastIndex = 0;
+  let html = '';
+  let match;
+
+  while ((match = IMG_REGEX.exec(value)) !== null) {
+    // Escape text before this img tag
+    const before = value.slice(lastIndex, match.index);
+    html += before
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\n/g, '<br>');
+
+    // Validate and re-build img tag with escaped attributes
+    const src = match[1];
+    const alt = match[2];
+    const sanitized = sanitizeImgTag(src, alt);
+    if (sanitized) {
+      html += sanitized;
+    }
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  // Escape remaining text after last img tag
+  const remaining = value.slice(lastIndex);
+  html += remaining
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\n/g, '<br>');
+
+  return html;
 }
 
 export default function MentionInput({
@@ -87,23 +155,9 @@ export default function MentionInput({
       return;
     }
 
-    // Only sync if the value has actually changed from what's in the editor
     const currentText = getTextContent(el);
     if (currentText !== value) {
-      // Convert value to HTML: preserve img tags, convert newlines to <br>
-      const html = value
-        .replace(/(<img [^>]+>)/g, '\x00$1\x00') // protect img tags
-        .split('\x00')
-        .map((part) => {
-          if (part.startsWith('<img ')) return part;
-          return part
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/\n/g, '<br>');
-        })
-        .join('');
-      el.innerHTML = html || '';
+      el.innerHTML = valueToSafeHtml(value) || '';
     }
     setIsEmpty(!value);
   }, [value]);
@@ -241,7 +295,6 @@ export default function MentionInput({
 
     const mentionText = `@${user.displayName} `;
     const text = getTextContent(el);
-    // Strip img tags for text-position calculation
     const plainText = text.replace(/<img [^>]+>/g, '');
     const before = plainText.slice(0, mentionStartIndex);
     const after = plainText.slice(mentionStartIndex + 1 + mentionQuery.length);
@@ -260,7 +313,7 @@ export default function MentionInput({
       }
     }
 
-    isInternalUpdate.current = false; // Allow sync
+    isInternalUpdate.current = false;
     onChange(finalValue);
 
     setShowSuggestions(false);
@@ -270,27 +323,13 @@ export default function MentionInput({
     requestAnimationFrame(() => el.focus());
   };
 
-  // Handle paste — delegate to parent for image handling
+  // Handle paste — always preventDefault to block raw HTML injection
   const handlePaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
-    // Debug: log clipboard contents
-    console.log('[MentionInput paste]', {
-      filesCount: e.clipboardData?.files?.length,
-      fileTypes: e.clipboardData?.files
-        ? Array.from(e.clipboardData.files).map((f) => f.type)
-        : [],
-      itemsCount: e.clipboardData?.items?.length,
-      itemTypes: e.clipboardData?.items
-        ? Array.from(e.clipboardData.items).map((i) => `${i.kind}:${i.type}`)
-        : [],
-      hasOnPaste: !!onPaste,
-    });
-
-    // Check for images in clipboardData.files (Chrome/Edge screenshots)
+    // Check for images in clipboard
     const hasFileImages =
       e.clipboardData?.files?.length > 0 &&
       Array.from(e.clipboardData.files).some((f) => f.type.startsWith('image/'));
 
-    // Also check clipboardData.items (Firefox, some Windows paste scenarios)
     const hasItemImages =
       !hasFileImages &&
       e.clipboardData?.items &&
@@ -299,17 +338,19 @@ export default function MentionInput({
       );
 
     if ((hasFileImages || hasItemImages) && onPaste) {
+      // Delegate image handling to parent — parent must call preventDefault
       onPaste(e);
       return;
     }
 
-    // For non-image paste, strip HTML formatting and insert as plain text
-    const text = e.clipboardData?.getData('text/plain');
+    // Always prevent default to block arbitrary HTML injection from clipboard
+    e.preventDefault();
+
+    // Insert plain text only (strip any HTML formatting)
+    const text = e.clipboardData?.getData('text/plain') || '';
     if (text) {
-      e.preventDefault();
       document.execCommand('insertText', false, text);
     }
-    // If no text and no images, let the browser handle it (e.g. empty paste)
   };
 
   // Scroll selected into view

--- a/src/components/common/MentionInput.tsx
+++ b/src/components/common/MentionInput.tsx
@@ -14,6 +14,7 @@ import Avatar from './Avatar';
 interface MentionInputProps {
   value: string;
   onChange: (value: string) => void;
+  onPaste?: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void;
   placeholder?: string;
   className?: string;
   disabled?: boolean;
@@ -26,6 +27,7 @@ interface MentionUser extends User {
 export default function MentionInput({
   value,
   onChange,
+  onPaste,
   placeholder = 'Type your message...',
   className = '',
   disabled = false,
@@ -249,6 +251,7 @@ export default function MentionInput({
         value={value}
         onChange={handleChange}
         onKeyDown={handleKeyDown}
+        onPaste={onPaste}
         placeholder={placeholder}
         disabled={disabled}
         className={className}

--- a/src/components/common/MentionInput.tsx
+++ b/src/components/common/MentionInput.tsx
@@ -375,7 +375,7 @@ export default function MentionInput({
         role="textbox"
         aria-multiline="true"
         aria-placeholder={placeholder}
-        style={{ minHeight: '100px', overflowY: 'auto' }}
+        style={{ overflowY: 'auto' }}
       />
       {/* Placeholder overlay */}
       {isEmpty && (

--- a/src/components/tickets/CommentSection.tsx
+++ b/src/components/tickets/CommentSection.tsx
@@ -4,12 +4,14 @@ import { useState } from 'react';
 import { format } from 'date-fns';
 import { Send, Zap, Paperclip, Loader2 } from 'lucide-react';
 import Avatar from '@/components/common/Avatar';
-import type { TicketComment, User } from '@/types';
+import MentionInput from '@/components/common/MentionInput';
+import type { TicketComment, User, Attachment } from '@/types';
 
 interface CommentSectionProps {
   comments: TicketComment[];
   isLoading?: boolean;
   onAddComment?: (comment: string) => Promise<void>;
+  onUploadAttachment?: (file: File) => Promise<Attachment>;
   assignee?: User | null;
   onZapClick?: () => void;
   compact?: boolean;
@@ -19,12 +21,14 @@ export default function CommentSection({
   comments,
   isLoading = false,
   onAddComment,
+  onUploadAttachment,
   assignee,
   onZapClick,
   compact = false,
 }: CommentSectionProps) {
   const [newComment, setNewComment] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isPastingImage, setIsPastingImage] = useState(false);
 
   const handleSubmit = async () => {
     if (!newComment.trim() || !onAddComment) return;
@@ -34,6 +38,62 @@ export default function CommentSection({
       setNewComment('');
     } finally {
       setIsSubmitting(false);
+    }
+  };
+
+  const handlePaste = async (e: React.ClipboardEvent<HTMLDivElement>) => {
+    if (!onUploadAttachment) return;
+
+    const imageFiles: File[] = [];
+
+    if (e.clipboardData?.files) {
+      for (let i = 0; i < e.clipboardData.files.length; i++) {
+        const file = e.clipboardData.files[i];
+        if (file.type.startsWith('image/')) imageFiles.push(file);
+      }
+    }
+
+    if (imageFiles.length === 0 && e.clipboardData?.items) {
+      for (let i = 0; i < e.clipboardData.items.length; i++) {
+        const item = e.clipboardData.items[i];
+        if (item.kind === 'file' && item.type.startsWith('image/')) {
+          const file = item.getAsFile();
+          if (file) imageFiles.push(file);
+        }
+      }
+    }
+
+    if (imageFiles.length === 0) return;
+
+    e.preventDefault();
+    setIsPastingImage(true);
+
+    try {
+      for (const file of imageFiles) {
+        const ext = file.type.split('/')[1] || 'png';
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+        const namedFile = new File([file], `pasted-image-${timestamp}.${ext}`, {
+          type: file.type,
+        });
+        const attachment = await onUploadAttachment(namedFile);
+        const idMatch = attachment.url?.match(/attachments\/([a-f0-9-]+)/i);
+        const orgMatch = attachment.url?.match(/dev\.azure\.com\/([^/]+)/);
+        const attachmentId = idMatch ? idMatch[1] : null;
+        const org = orgMatch ? orgMatch[1] : '';
+        const params = new URLSearchParams({
+          fileName: namedFile.name,
+          ...(org && { org }),
+        });
+        const imgSrc = attachmentId
+          ? `/api/devops/attachments/${attachmentId}?${params.toString()}`
+          : attachment.url;
+        const imgHtml = `<img src="${imgSrc}" alt="${namedFile.name}" />`;
+        setNewComment((prev) => (prev ? `${prev}\n${imgHtml}` : imgHtml));
+      }
+    } catch (error) {
+      console.error('Failed to upload pasted image:', error);
+    } finally {
+      setIsPastingImage(false);
     }
   };
 
@@ -126,22 +186,32 @@ export default function CommentSection({
           )}
 
           <div>
-            <textarea
+            <MentionInput
               value={newComment}
-              onChange={(e) => setNewComment(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && !e.shiftKey && compact) {
-                  e.preventDefault();
-                  handleSubmit();
-                }
-              }}
-              placeholder={compact ? 'Add a comment...' : 'Type your reply...'}
+              onChange={setNewComment}
+              onPaste={onUploadAttachment ? handlePaste : undefined}
+              placeholder={
+                compact
+                  ? 'Add a comment... Paste images with Ctrl+V'
+                  : 'Type your reply... Paste images with Ctrl+V'
+              }
               className={`input w-full resize-none ${compact ? 'min-h-[60px] text-sm' : 'min-h-[100px]'}`}
-              disabled={isSubmitting}
+              disabled={isSubmitting || isPastingImage}
             />
+            {isPastingImage && (
+              <div
+                className="mt-1 flex items-center gap-2 text-xs"
+                style={{ color: 'var(--text-muted)' }}
+              >
+                <Loader2 size={12} className="animate-spin" />
+                Uploading pasted image...
+              </div>
+            )}
             <div className="mt-2 flex items-center justify-end gap-2">
               <button
-                onClick={() => alert('Attachments not yet implemented')}
+                onClick={() =>
+                  alert('Use Ctrl+V to paste images, or use the full view for file attachments')
+                }
                 className="rounded p-2 transition-colors hover:bg-[var(--surface-hover)]"
                 style={{ color: 'var(--text-muted)' }}
                 title="Attach file"

--- a/src/components/tickets/NewTicketDialog.tsx
+++ b/src/components/tickets/NewTicketDialog.tsx
@@ -5,6 +5,7 @@ import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { X, Send, Loader2, Search, Paperclip } from 'lucide-react';
 import { useDevOpsApi } from '@/hooks/useDevOpsApi';
+import MentionInput from '@/components/common/MentionInput';
 import type { DevOpsProject, User, WorkItemType, ClassificationNode } from '@/types';
 import { ALLOWED_ATTACHMENT_TYPES } from '@/types';
 import { formatFileSize, validateFile } from '@/lib/attachment-utils';
@@ -567,10 +568,48 @@ export default function NewTicketDialog({ isOpen, onClose }: NewTicketDialogProp
 
               {/* Description */}
               <div>
-                <textarea
-                  placeholder="Description..."
+                <MentionInput
+                  placeholder="Description... Paste images with Ctrl+V"
                   value={form.description}
-                  onChange={(e) => setForm((prev) => ({ ...prev, description: e.target.value }))}
+                  onChange={(val) => setForm((prev) => ({ ...prev, description: val }))}
+                  onPaste={(e) => {
+                    // Convert pasted images to inline base64 data URLs
+                    const files = e.clipboardData?.files;
+                    const items = e.clipboardData?.items;
+                    const imageFiles: File[] = [];
+
+                    if (files) {
+                      for (let i = 0; i < files.length; i++) {
+                        if (files[i].type.startsWith('image/')) imageFiles.push(files[i]);
+                      }
+                    }
+                    if (imageFiles.length === 0 && items) {
+                      for (let i = 0; i < items.length; i++) {
+                        if (items[i].kind === 'file' && items[i].type.startsWith('image/')) {
+                          const f = items[i].getAsFile();
+                          if (f) imageFiles.push(f);
+                        }
+                      }
+                    }
+
+                    if (imageFiles.length === 0) return;
+                    e.preventDefault();
+
+                    for (const file of imageFiles) {
+                      const reader = new FileReader();
+                      reader.onload = () => {
+                        const dataUrl = reader.result as string;
+                        const imgHtml = `<img src="${dataUrl}" alt="${file.name}" />`;
+                        setForm((prev) => ({
+                          ...prev,
+                          description: prev.description
+                            ? `${prev.description}\n${imgHtml}`
+                            : imgHtml,
+                        }));
+                      };
+                      reader.readAsDataURL(file);
+                    }
+                  }}
                   className="input min-h-[200px] w-full resize-none"
                 />
               </div>

--- a/src/components/tickets/TicketDetail.tsx
+++ b/src/components/tickets/TicketDetail.tsx
@@ -929,7 +929,7 @@ export default function TicketDetail({
               onChange={setNewComment}
               onPaste={handleCommentPaste}
               placeholder="Type your reply... Use @ to mention team members. Paste images with Ctrl+V."
-              className="input min-h-[100px] w-full resize-none pr-24"
+              className="input max-h-[300px] min-h-[100px] w-full resize-none overflow-auto pr-24"
               disabled={isPastingImage}
             />
             {isPastingImage && (

--- a/src/components/tickets/TicketDetail.tsx
+++ b/src/components/tickets/TicketDetail.tsx
@@ -385,11 +385,17 @@ export default function TicketDetail({
     try {
       for (const file of namedFiles) {
         const attachment = await onUploadAttachment(file);
-        // Extract attachment ID from DevOps URL and use our proxy
+        // Extract attachment ID and org from DevOps URL, use our proxy
         const idMatch = attachment.url?.match(/attachments\/([a-f0-9-]+)/i);
+        const orgMatch = attachment.url?.match(/dev\.azure\.com\/([^/]+)/);
         const attachmentId = idMatch ? idMatch[1] : null;
+        const org = orgMatch ? orgMatch[1] : '';
+        const params = new URLSearchParams({
+          fileName: file.name,
+          ...(org && { org }),
+        });
         const imgSrc = attachmentId
-          ? `/api/devops/attachments/${attachmentId}?fileName=${encodeURIComponent(file.name)}`
+          ? `/api/devops/attachments/${attachmentId}?${params.toString()}`
           : attachment.url;
         const imgHtml = `<img src="${imgSrc}" alt="${file.name}" />`;
         setNewComment((prev) => (prev ? `${prev}\n${imgHtml}` : imgHtml));

--- a/src/components/tickets/TicketDetail.tsx
+++ b/src/components/tickets/TicketDetail.tsx
@@ -339,6 +339,53 @@ export default function TicketDetail({
     }
   };
 
+  // Paste image handler
+  const [isPastingImage, setIsPastingImage] = useState(false);
+  const [pastedImages, setPastedImages] = useState<Array<{ name: string; url: string }>>([]);
+
+  const handleCommentPaste = async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = e.clipboardData?.items;
+    if (!items || !onUploadAttachment) return;
+
+    const imageFiles: File[] = [];
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (item.type.startsWith('image/')) {
+        const file = item.getAsFile();
+        if (file) {
+          // Generate a descriptive filename
+          const ext = item.type.split('/')[1] || 'png';
+          const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+          const namedFile = new File([file], `pasted-image-${timestamp}.${ext}`, {
+            type: item.type,
+          });
+          imageFiles.push(namedFile);
+        }
+      }
+    }
+
+    if (imageFiles.length === 0) return;
+
+    // Prevent default paste of image data as text
+    e.preventDefault();
+    setIsPastingImage(true);
+    setUploadError(null);
+
+    try {
+      for (const file of imageFiles) {
+        const attachment = await onUploadAttachment(file);
+        // Insert inline image HTML into the comment
+        const imgHtml = `<img src="${attachment.url}" alt="${file.name}" />`;
+        setNewComment((prev) => (prev ? `${prev}\n${imgHtml}` : imgHtml));
+        setPastedImages((prev) => [...prev, { name: file.name, url: attachment.url }]);
+      }
+    } catch (error) {
+      setUploadError(error instanceof Error ? error.message : 'Failed to upload pasted image');
+    } finally {
+      setIsPastingImage(false);
+    }
+  };
+
   // File attachment handlers
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
@@ -392,6 +439,7 @@ export default function TicketDetail({
       if (newComment.trim() && onAddComment) {
         await onAddComment(newComment);
         setNewComment('');
+        setPastedImages([]);
       }
 
       // Refresh ticket once after all uploads and comment
@@ -859,9 +907,53 @@ export default function TicketDetail({
             <MentionInput
               value={newComment}
               onChange={setNewComment}
-              placeholder="Type your reply... Use @ to mention team members"
+              onPaste={handleCommentPaste}
+              placeholder="Type your reply... Use @ to mention team members. Paste images with Ctrl+V."
               className="input min-h-[100px] w-full resize-none pr-24"
+              disabled={isPastingImage}
             />
+            {/* Pasted image previews */}
+            {pastedImages.length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-2">
+                {pastedImages.map((img, idx) => (
+                  <div
+                    key={idx}
+                    className="relative rounded border"
+                    style={{ borderColor: 'var(--border)' }}
+                  >
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img src={img.url} alt={img.name} className="h-16 w-16 rounded object-cover" />
+                    <button
+                      onClick={() => {
+                        setPastedImages((prev) => prev.filter((_, i) => i !== idx));
+                        // Remove the img tag from comment
+                        setNewComment((prev) =>
+                          prev.replace(`<img src="${img.url}" alt="${img.name}" />`, '').trim()
+                        );
+                      }}
+                      className="absolute -top-1.5 -right-1.5 rounded-full p-0.5"
+                      style={{
+                        backgroundColor: 'var(--surface)',
+                        color: 'var(--text-muted)',
+                        border: '1px solid var(--border)',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      <X size={10} />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+            {isPastingImage && (
+              <div
+                className="mt-1 flex items-center gap-2 text-xs"
+                style={{ color: 'var(--text-muted)' }}
+              >
+                <Loader2 size={12} className="animate-spin" />
+                Uploading pasted image...
+              </div>
+            )}
             <div className="absolute right-3 bottom-3 flex items-center gap-2">
               <button
                 onClick={() => fileInputRef.current?.click()}

--- a/src/components/tickets/TicketDetail.tsx
+++ b/src/components/tickets/TicketDetail.tsx
@@ -341,43 +341,58 @@ export default function TicketDetail({
 
   // Paste image handler
   const [isPastingImage, setIsPastingImage] = useState(false);
-  const [pastedImages, setPastedImages] = useState<Array<{ name: string; url: string }>>([]);
 
-  const handleCommentPaste = async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
-    const items = e.clipboardData?.items;
-    if (!items || !onUploadAttachment) return;
+  const handleCommentPaste = async (e: React.ClipboardEvent<HTMLDivElement>) => {
+    if (!onUploadAttachment) return;
 
+    // Collect image files from clipboardData.files and clipboardData.items
     const imageFiles: File[] = [];
-    for (let i = 0; i < items.length; i++) {
-      const item = items[i];
-      if (item.type.startsWith('image/')) {
-        const file = item.getAsFile();
-        if (file) {
-          // Generate a descriptive filename
-          const ext = item.type.split('/')[1] || 'png';
-          const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-          const namedFile = new File([file], `pasted-image-${timestamp}.${ext}`, {
-            type: item.type,
-          });
-          imageFiles.push(namedFile);
+
+    // Try files first (Chrome/Edge)
+    if (e.clipboardData?.files) {
+      for (let i = 0; i < e.clipboardData.files.length; i++) {
+        const file = e.clipboardData.files[i];
+        if (file.type.startsWith('image/')) {
+          imageFiles.push(file);
+        }
+      }
+    }
+
+    // Fallback to items (Firefox, some Windows scenarios)
+    if (imageFiles.length === 0 && e.clipboardData?.items) {
+      for (let i = 0; i < e.clipboardData.items.length; i++) {
+        const item = e.clipboardData.items[i];
+        if (item.kind === 'file' && item.type.startsWith('image/')) {
+          const file = item.getAsFile();
+          if (file) imageFiles.push(file);
         }
       }
     }
 
     if (imageFiles.length === 0) return;
 
-    // Prevent default paste of image data as text
+    // Rename files with descriptive names
+    const namedFiles = imageFiles.map((file) => {
+      const ext = file.type.split('/')[1] || 'png';
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+      return new File([file], `pasted-image-${timestamp}.${ext}`, { type: file.type });
+    });
+
     e.preventDefault();
     setIsPastingImage(true);
     setUploadError(null);
 
     try {
-      for (const file of imageFiles) {
+      for (const file of namedFiles) {
         const attachment = await onUploadAttachment(file);
-        // Insert inline image HTML into the comment
-        const imgHtml = `<img src="${attachment.url}" alt="${file.name}" />`;
+        // Extract attachment ID from DevOps URL and use our proxy
+        const idMatch = attachment.url?.match(/attachments\/([a-f0-9-]+)/i);
+        const attachmentId = idMatch ? idMatch[1] : null;
+        const imgSrc = attachmentId
+          ? `/api/devops/attachments/${attachmentId}?fileName=${encodeURIComponent(file.name)}`
+          : attachment.url;
+        const imgHtml = `<img src="${imgSrc}" alt="${file.name}" />`;
         setNewComment((prev) => (prev ? `${prev}\n${imgHtml}` : imgHtml));
-        setPastedImages((prev) => [...prev, { name: file.name, url: attachment.url }]);
       }
     } catch (error) {
       setUploadError(error instanceof Error ? error.message : 'Failed to upload pasted image');
@@ -439,7 +454,6 @@ export default function TicketDetail({
       if (newComment.trim() && onAddComment) {
         await onAddComment(newComment);
         setNewComment('');
-        setPastedImages([]);
       }
 
       // Refresh ticket once after all uploads and comment
@@ -912,39 +926,6 @@ export default function TicketDetail({
               className="input min-h-[100px] w-full resize-none pr-24"
               disabled={isPastingImage}
             />
-            {/* Pasted image previews */}
-            {pastedImages.length > 0 && (
-              <div className="mt-2 flex flex-wrap gap-2">
-                {pastedImages.map((img, idx) => (
-                  <div
-                    key={idx}
-                    className="relative rounded border"
-                    style={{ borderColor: 'var(--border)' }}
-                  >
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img src={img.url} alt={img.name} className="h-16 w-16 rounded object-cover" />
-                    <button
-                      onClick={() => {
-                        setPastedImages((prev) => prev.filter((_, i) => i !== idx));
-                        // Remove the img tag from comment
-                        setNewComment((prev) =>
-                          prev.replace(`<img src="${img.url}" alt="${img.name}" />`, '').trim()
-                        );
-                      }}
-                      className="absolute -top-1.5 -right-1.5 rounded-full p-0.5"
-                      style={{
-                        backgroundColor: 'var(--surface)',
-                        color: 'var(--text-muted)',
-                        border: '1px solid var(--border)',
-                        cursor: 'pointer',
-                      }}
-                    >
-                      <X size={10} />
-                    </button>
-                  </div>
-                ))}
-              </div>
-            )}
             {isPastingImage && (
               <div
                 className="mt-1 flex items-center gap-2 text-xs"

--- a/src/components/tickets/WorkItemDetailContent.tsx
+++ b/src/components/tickets/WorkItemDetailContent.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { format } from 'date-fns';
 import { Pencil, Check, X, Loader2 } from 'lucide-react';
-import type { WorkItem, TicketComment } from '@/types';
+import type { WorkItem, TicketComment, Attachment } from '@/types';
 import Avatar from '../common/Avatar';
 import CommentSection from './CommentSection';
 import ZapDialog from './ZapDialog';
@@ -13,6 +13,7 @@ interface WorkItemDetailContentProps {
   comments: TicketComment[];
   isLoadingComments?: boolean;
   onAddComment?: (comment: string) => Promise<void>;
+  onUploadAttachment?: (file: File) => Promise<Attachment>;
   onUpdate?: (updates: { title?: string; description?: string }) => Promise<void>;
   onZapSent?: (amount: number) => void;
   showRequester?: boolean;
@@ -31,6 +32,7 @@ export default function WorkItemDetailContent({
   comments,
   isLoadingComments = false,
   onAddComment,
+  onUploadAttachment,
   onUpdate,
   onZapSent,
   showRequester = false,
@@ -253,6 +255,7 @@ export default function WorkItemDetailContent({
             comments={comments}
             isLoading={isLoadingComments}
             onAddComment={onAddComment}
+            onUploadAttachment={onUploadAttachment}
             assignee={workItem.assignee}
             onZapClick={() => setIsZapDialogOpen(true)}
             compact
@@ -263,6 +266,7 @@ export default function WorkItemDetailContent({
           comments={comments}
           isLoading={isLoadingComments}
           onAddComment={onAddComment}
+          onUploadAttachment={onUploadAttachment}
           assignee={workItem.assignee}
           onZapClick={() => setIsZapDialogOpen(true)}
         />

--- a/src/components/tickets/WorkItemDetailDialog.tsx
+++ b/src/components/tickets/WorkItemDetailDialog.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { ExternalLink, ChevronDown, Loader2, Maximize2 } from 'lucide-react';
-import type { WorkItem, TicketComment } from '@/types';
+import type { WorkItem, TicketComment, Attachment } from '@/types';
 import StatusBadge from '../common/StatusBadge';
 import TicketDialogShell from './TicketDialogShell';
 import { useWorkItemActions } from '@/hooks/useWorkItemActions';
@@ -127,6 +127,25 @@ export default function WorkItemDetailDialog({
       }
     },
     [workItem, fetchComments, fetchDevOps, hasOrganization]
+  );
+
+  const handleUploadAttachment = useCallback(
+    async (file: File): Promise<Attachment> => {
+      if (!workItem) throw new Error('No work item');
+      const formData = new FormData();
+      formData.append('file', file);
+      const response = await fetchDevOps(`/api/devops/tickets/${workItem.id}/attachments`, {
+        method: 'POST',
+        body: formData,
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed to upload attachment');
+      }
+      const data = await response.json();
+      return data.attachment;
+    },
+    [workItem, fetchDevOps]
   );
 
   const handleUpdate = useCallback(
@@ -296,6 +315,7 @@ export default function WorkItemDetailDialog({
         comments={comments}
         isLoadingComments={isLoadingComments}
         onAddComment={handleAddComment}
+        onUploadAttachment={handleUploadAttachment}
         onUpdate={onUpdate ? handleUpdate : undefined}
         showEffortTracking
         compact


### PR DESCRIPTION
## Summary
- Paste images directly into the comment input using Ctrl+V / Cmd+V — images render **inline** like Zendesk
- MentionInput converted from textarea to contentEditable div for rich content support
- Images auto-upload as Azure DevOps attachments and embed via proxy URL
- New attachment proxy route (`/api/devops/attachments/[id]`) serves files with authentication
- Inline image CSS for comments and descriptions

## Key Changes
- `src/components/common/MentionInput.tsx` — Rewritten as contentEditable div with @mention support preserved
- `src/components/tickets/TicketDetail.tsx` — Paste handler uploads images and inserts inline `<img>` tags
- `src/app/api/devops/attachments/[id]/route.ts` — New proxy route for authenticated attachment serving
- `src/app/globals.css` — Inline image styling for user content

## Screenshot
<img width="1743" height="1665" alt="image" src="https://github.com/user-attachments/assets/239be878-836c-4a28-a418-710193ec6ac1" />


## Test plan
- [x] Paste screenshot (Win+Shift+S) into comment input — image renders inline
- [x] Submit comment with inline image — image visible in comment thread
- [x] @mention suggestions still work in the new contentEditable input
- [x] Plain text paste (Ctrl+V) still works normally
- [x] Image also appears as attachment on the ticket in Azure DevOps

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)