### PR TITLE
fix: Add Removed state to work item state dropdown

### DIFF
--- a/src/app/api/devops/workitem-states/route.ts
+++ b/src/app/api/devops/workitem-states/route.ts
@@ -88,9 +88,9 @@ export async function GET(request: NextRequest) {
             states,
           });
 
-          // Collect unique states (excluding Removed)
+          // Collect unique states
           for (const state of states) {
-            if (state.name !== 'Removed' && !uniqueStates.has(state.name)) {
+            if (!uniqueStates.has(state.name)) {
               uniqueStates.set(state.name, state);
             }
           }
@@ -100,12 +100,13 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // Sort states by category order: Proposed -> InProgress -> Resolved -> Completed
+    // Sort states by category order: Proposed -> InProgress -> Resolved -> Completed -> Removed
     const categoryOrder: Record<string, number> = {
       Proposed: 1,
       InProgress: 2,
       Resolved: 3,
       Completed: 4,
+      Removed: 5,
     };
 
     const sortedStates = Array.from(uniqueStates.values()).sort((a, b) => {


### PR DESCRIPTION
## Summary
- Remove the filter that excluded "Removed" from the work item states API endpoint
- Add "Removed" category to the state sort order so it appears last in the dropdown
- Users can now delete/trash work items directly from ZapDesk without opening Azure DevOps

<img width="267" height="377" alt="image" src="https://github.com/user-attachments/assets/95edcf72-fdfa-40ef-9889-0b0f840f542e" />

Closes #329

## Test plan
- [x] Open any work item from the Kanban board or ticket list
- [x] Click the state dropdown
- [x] Verify "Removed" appears as an option at the bottom
- [x] Set a work item to "Removed" and confirm it updates in Azure DevOps

🤖 Generated with [Claude Code](https://claude.com/claude-code)