### PR TITLE
fix: Consistent edit button styling and placeholder text

### DIFF
--- a/src/components/tickets/CommentSection.tsx
+++ b/src/components/tickets/CommentSection.tsx
@@ -52,7 +52,7 @@ export default function CommentSection({
         </div>
       ) : comments.length === 0 ? (
         <p className="py-2 text-sm italic" style={{ color: 'var(--text-muted)' }}>
-          No comments yet
+          No comments
         </p>
       ) : (
         <div className={compact ? 'mb-4 space-y-3' : 'mb-4 space-y-4'}>

--- a/src/components/tickets/TicketDetail.tsx
+++ b/src/components/tickets/TicketDetail.tsx
@@ -406,7 +406,7 @@ export default function TicketDetail({
     setIsEditingDescription(false);
     // Reset content back to original
     if (descriptionRef.current) {
-      descriptionRef.current.innerHTML = ticket.description || '<em>No description provided</em>';
+      descriptionRef.current.innerHTML = ticket.description || '';
     }
   };
 
@@ -715,24 +715,30 @@ export default function TicketDetail({
                   </div>
                 )}
               </div>
-              <div
-                ref={descriptionRef}
-                contentEditable={isEditingDescription}
-                suppressContentEditableWarning
-                className={`prose prose-sm prose-invert user-content max-w-none ${isEditingDescription ? 'rounded-md border p-3 outline-none focus:ring-1' : ''}`}
-                style={{
-                  color: 'var(--text-secondary)',
-                  ...(isEditingDescription
-                    ? {
-                        borderColor: 'var(--border)',
-                        minHeight: '150px',
-                      }
-                    : {}),
-                }}
-                dangerouslySetInnerHTML={{
-                  __html: ticket.description || '<em>No description provided</em>',
-                }}
-              />
+              {ticket.description || isEditingDescription ? (
+                <div
+                  ref={descriptionRef}
+                  contentEditable={isEditingDescription}
+                  suppressContentEditableWarning
+                  className={`prose prose-sm prose-invert user-content max-w-none ${isEditingDescription ? 'rounded-md border p-3 outline-none focus:ring-1' : ''}`}
+                  style={{
+                    color: 'var(--text-secondary)',
+                    ...(isEditingDescription
+                      ? {
+                          borderColor: 'var(--border)',
+                          minHeight: '150px',
+                        }
+                      : {}),
+                  }}
+                  dangerouslySetInnerHTML={{
+                    __html: ticket.description || '',
+                  }}
+                />
+              ) : (
+                <p className="text-sm italic" style={{ color: 'var(--text-muted)' }}>
+                  No description
+                </p>
+              )}
               {/* System Info */}
               {ticket.systemInfo && (
                 <div className="mt-4 pt-4" style={{ borderTop: '1px solid var(--border)' }}>
@@ -781,7 +787,7 @@ export default function TicketDetail({
                   {onResolutionChange && !isEditingResolution && (
                     <button
                       onClick={handleStartEditResolution}
-                      className="text-sm"
+                      className="rounded-md px-3 py-1 text-sm transition-colors hover:bg-[var(--surface-hover)]"
                       style={{ color: 'var(--primary)' }}
                     >
                       Edit
@@ -790,20 +796,26 @@ export default function TicketDetail({
                   {isEditingResolution && (
                     <div className="flex items-center gap-2">
                       <button
-                        onClick={handleSaveResolution}
-                        disabled={isSavingResolution}
-                        className="text-sm"
-                        style={{ color: 'var(--primary)' }}
-                      >
-                        {isSavingResolution ? 'Saving...' : 'Save'}
-                      </button>
-                      <button
                         onClick={handleCancelResolution}
                         disabled={isSavingResolution}
-                        className="text-sm"
+                        className="rounded-md px-3 py-1 text-sm transition-colors hover:bg-[var(--surface-hover)]"
                         style={{ color: 'var(--text-muted)' }}
                       >
                         Cancel
+                      </button>
+                      <button
+                        onClick={handleSaveResolution}
+                        disabled={isSavingResolution}
+                        className="btn-primary flex items-center gap-1 px-3 py-1 text-sm"
+                      >
+                        {isSavingResolution ? (
+                          <>
+                            <Loader2 size={14} className="animate-spin" />
+                            Saving...
+                          </>
+                        ) : (
+                          'Save'
+                        )}
                       </button>
                     </div>
                   )}
@@ -833,7 +845,7 @@ export default function TicketDetail({
                     }}
                     onClick={onResolutionChange ? handleStartEditResolution : undefined}
                   >
-                    No resolution — click to add
+                    No resolution
                   </button>
                 )}
               </div>
@@ -950,8 +962,8 @@ export default function TicketDetail({
                   ))}
                 </div>
               ) : (
-                <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
-                  No comments yet.
+                <p className="text-sm italic" style={{ color: 'var(--text-muted)' }}>
+                  No comments
                 </p>
               )}
             </div>

--- a/src/components/tickets/WorkItemDetailContent.tsx
+++ b/src/components/tickets/WorkItemDetailContent.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { format } from 'date-fns';
-import { Pencil, Check, X, Loader2 } from 'lucide-react';
+import { Check, X, Loader2 } from 'lucide-react';
 import type { WorkItem, TicketComment } from '@/types';
 import { getTemplateConfig, hasResolutionField } from '@/config/process-templates';
 import Avatar from '../common/Avatar';

--- a/src/components/tickets/WorkItemDetailContent.tsx
+++ b/src/components/tickets/WorkItemDetailContent.tsx
@@ -78,36 +78,37 @@ function ResolutionField({
         {onUpdate && !isEditing && (
           <button
             onClick={handleStartEdit}
-            className="rounded p-1 transition-colors hover:bg-[var(--surface-hover)]"
+            className="rounded-md px-3 py-1 text-sm transition-colors hover:bg-[var(--surface-hover)]"
+            style={{ color: 'var(--primary)' }}
             title="Edit resolution"
           >
-            <Pencil size={12} style={{ color: 'var(--text-muted)' }} />
+            Edit
           </button>
         )}
         {isEditing && (
-          <div className="flex items-center gap-1">
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleCancel}
+              className="rounded-md px-3 py-1 text-sm transition-colors hover:bg-[var(--surface-hover)]"
+              style={{ color: 'var(--text-muted)' }}
+              title="Cancel"
+            >
+              Cancel
+            </button>
             <button
               onClick={handleSave}
               disabled={isSaving}
-              className="rounded p-1 transition-colors hover:bg-[var(--surface-hover)]"
+              className="btn-primary flex items-center gap-1 px-3 py-1 text-sm"
               title="Save"
             >
               {isSaving ? (
-                <Loader2
-                  size={12}
-                  className="animate-spin"
-                  style={{ color: 'var(--text-muted)' }}
-                />
+                <>
+                  <Loader2 size={14} className="animate-spin" />
+                  Saving...
+                </>
               ) : (
-                <Check size={12} style={{ color: 'var(--primary)' }} />
+                'Save'
               )}
-            </button>
-            <button
-              onClick={handleCancel}
-              className="rounded p-1 transition-colors hover:bg-[var(--surface-hover)]"
-              title="Cancel"
-            >
-              <X size={12} style={{ color: 'var(--text-muted)' }} />
             </button>
           </div>
         )}
@@ -134,7 +135,7 @@ function ResolutionField({
           style={{ color: 'var(--text-muted)', cursor: onUpdate ? 'pointer' : 'default' }}
           onClick={onUpdate ? handleStartEdit : undefined}
         >
-          No resolution — click to add
+          No resolution
         </button>
       )}
     </div>
@@ -252,11 +253,10 @@ export default function WorkItemDetailContent({
             ) : (
               <button
                 onClick={handleStartEdit}
-                className="flex items-center gap-1 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-[var(--surface-hover)]"
-                style={{ color: 'var(--text-secondary)' }}
+                className="rounded-md px-3 py-1 text-sm transition-colors hover:bg-[var(--surface-hover)]"
+                style={{ color: 'var(--primary)' }}
                 title="Edit title and description"
               >
-                <Pencil size={14} />
                 Edit
               </button>
             )}
@@ -315,7 +315,7 @@ export default function WorkItemDetailContent({
             />
           ) : (
             <p className="text-sm italic" style={{ color: 'var(--text-muted)' }}>
-              No description provided
+              No description
             </p>
           )}
         </div>

--- a/src/components/tickets/WorkItemDetailContent.tsx
+++ b/src/components/tickets/WorkItemDetailContent.tsx
@@ -89,6 +89,7 @@ function ResolutionField({
           <div className="flex items-center gap-2">
             <button
               onClick={handleCancel}
+              disabled={isSaving}
               className="rounded-md px-3 py-1 text-sm transition-colors hover:bg-[var(--surface-hover)]"
               style={{ color: 'var(--text-muted)' }}
               title="Cancel"


### PR DESCRIPTION
## Summary
- Standardized all Edit button styling across ticket detail views (TicketDetail.tsx and WorkItemDetailContent.tsx) — consistent `rounded-md`, padding, hover effect, and primary color
- Standardized Save/Cancel button pairs to match Description field pattern (Cancel text button + primary Save button with spinner)
- Made all empty field placeholder text consistent: italic, muted color, same size ("No description", "No resolution", "No comments")

Closes #343
Closes #344
Closes #345

## Test plan
- [x] Open a ticket with both Description and Resolution fields — Edit buttons should look identical
- [x] Open a ticket via the Kanban dialog/sidebar — Edit buttons should match the full page view
- [x] Check empty Description, Resolution, and Comments placeholders are all italic, same size and color
- [x] Test edit/save/cancel flows still work correctly for Description and Resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)