### PR TITLE
feat: Add editable mitigation field for Issue and Risk work items

### DIFF
--- a/src/app/api/devops/tickets/[id]/route.ts
+++ b/src/app/api/devops/tickets/[id]/route.ts
@@ -75,6 +75,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       title,
       description,
       resolution,
+      mitigation,
       workItemType,
     } = body;
 
@@ -98,6 +99,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       title?: string;
       description?: string;
       resolution?: string;
+      mitigation?: string;
       workItemType?: string;
     } = {};
 
@@ -128,6 +130,10 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 
     if (resolution !== undefined) {
       updates.resolution = resolution;
+    }
+
+    if (mitigation !== undefined) {
+      updates.mitigation = mitigation;
     }
 
     // Update the work item

--- a/src/app/tickets/[id]/page.tsx
+++ b/src/app/tickets/[id]/page.tsx
@@ -267,6 +267,30 @@ export default function TicketDetailPage() {
     }
   };
 
+  const handleMitigationChange = async (mitigation: string) => {
+    if (!ticket) return;
+    try {
+      const response = await fetch(`/api/devops/tickets/${ticketId}`, {
+        method: 'PATCH',
+        headers: orgHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({
+          mitigation,
+          project: ticket.project,
+          workItemType: ticket.workItemType,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to update mitigation');
+      }
+
+      await fetchTicket();
+    } catch (error) {
+      console.error('Failed to update mitigation:', error);
+      throw error;
+    }
+  };
+
   const handleUploadAttachment = async (file: File): Promise<Attachment> => {
     const formData = new FormData();
     formData.append('file', file);
@@ -314,6 +338,7 @@ export default function TicketDetailPage() {
         onTypeChange={handleTypeChange}
         onDescriptionChange={handleDescriptionChange}
         onResolutionChange={handleResolutionChange}
+        onMitigationChange={handleMitigationChange}
         onUploadAttachment={handleUploadAttachment}
         onRefreshTicket={fetchTicket}
       />

--- a/src/components/tickets/TicketDetail.tsx
+++ b/src/components/tickets/TicketDetail.tsx
@@ -935,11 +935,12 @@ export default function TicketDetail({
                     autoFocus
                   />
                 ) : ticket.mitigation ? (
-                  <div
-                    className="prose prose-sm prose-invert user-content max-w-none"
+                  <p
+                    className="text-sm whitespace-pre-wrap"
                     style={{ color: 'var(--text-secondary)' }}
-                    dangerouslySetInnerHTML={{ __html: ticket.mitigation }}
-                  />
+                  >
+                    {ticket.mitigation}
+                  </p>
                 ) : (
                   <button
                     type="button"

--- a/src/components/tickets/TicketDetail.tsx
+++ b/src/components/tickets/TicketDetail.tsx
@@ -43,7 +43,11 @@ import ZapDialog from './ZapDialog';
 import TicketHistory from './TicketHistory';
 import TypeChangeRequiredFields from './TypeChangeRequiredFields';
 import type { RequiredField } from '@/hooks/useWorkItemActions';
-import { getTemplateConfig, hasResolutionField } from '@/config/process-templates';
+import {
+  getTemplateConfig,
+  hasMitigationField,
+  hasResolutionField,
+} from '@/config/process-templates';
 import { useClickOutside } from '@/hooks';
 import { useDevOpsApi } from '@/hooks/useDevOpsApi';
 
@@ -61,6 +65,7 @@ interface TicketDetailProps {
   onTypeChange?: (type: string, additionalFields?: Record<string, string>) => Promise<void>;
   onDescriptionChange?: (description: string) => Promise<void>;
   onResolutionChange?: (resolution: string) => Promise<void>;
+  onMitigationChange?: (mitigation: string) => Promise<void>;
   onUploadAttachment?: (file: File) => Promise<Attachment>;
   onRefreshTicket?: () => Promise<void>;
   processTemplate?: string;
@@ -85,12 +90,14 @@ export default function TicketDetail({
   onTypeChange,
   onDescriptionChange,
   onResolutionChange,
+  onMitigationChange,
   onUploadAttachment,
   onRefreshTicket,
   processTemplate,
 }: TicketDetailProps) {
   const templateConfig = getTemplateConfig(processTemplate);
   const showResolution = hasResolutionField(ticket.workItemType, templateConfig);
+  const showMitigation = hasMitigationField(ticket.workItemType, templateConfig);
   const [activeTab, setActiveTab] = useState<DetailTab>('details');
   const [newComment, setNewComment] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -169,6 +176,11 @@ export default function TicketDetail({
   const [isEditingResolution, setIsEditingResolution] = useState(false);
   const [isSavingResolution, setIsSavingResolution] = useState(false);
   const [editResolution, setEditResolution] = useState('');
+
+  // Mitigation editing state
+  const [isEditingMitigation, setIsEditingMitigation] = useState(false);
+  const [isSavingMitigation, setIsSavingMitigation] = useState(false);
+  const [editMitigation, setEditMitigation] = useState('');
 
   // Attachment state
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
@@ -446,6 +458,31 @@ export default function TicketDetail({
   const handleCancelResolution = () => {
     setIsEditingResolution(false);
     setEditResolution('');
+  };
+
+  const handleStartEditMitigation = () => {
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = ticket.mitigation || '';
+    setEditMitigation(tempDiv.textContent || tempDiv.innerText || '');
+    setIsEditingMitigation(true);
+  };
+
+  const handleSaveMitigation = async () => {
+    if (!onMitigationChange) return;
+    setIsSavingMitigation(true);
+    try {
+      await onMitigationChange(editMitigation);
+      setIsEditingMitigation(false);
+    } catch (error) {
+      console.error('Failed to save mitigation:', error);
+    } finally {
+      setIsSavingMitigation(false);
+    }
+  };
+
+  const handleCancelMitigation = () => {
+    setIsEditingMitigation(false);
+    setEditMitigation('');
   };
 
   // File attachment handlers
@@ -834,6 +871,86 @@ export default function TicketDetail({
                     onClick={onResolutionChange ? handleStartEditResolution : undefined}
                   >
                     No resolution — click to add
+                  </button>
+                )}
+              </div>
+            )}
+
+            {/* Mitigation (editable) - only for work item types that support it */}
+            {showMitigation && (
+              <div className="card p-4">
+                <div className="mb-2 flex items-center justify-between">
+                  <h3
+                    className="text-xs font-medium uppercase"
+                    style={{ color: 'var(--text-muted)' }}
+                  >
+                    Mitigation
+                  </h3>
+                  {onMitigationChange && (
+                    <div className="flex items-center gap-2">
+                      {isEditingMitigation ? (
+                        <>
+                          <button
+                            onClick={handleCancelMitigation}
+                            disabled={isSavingMitigation}
+                            className="rounded-md px-3 py-1 text-sm transition-colors hover:bg-[var(--surface-hover)]"
+                            style={{ color: 'var(--text-muted)' }}
+                          >
+                            Cancel
+                          </button>
+                          <button
+                            onClick={handleSaveMitigation}
+                            disabled={isSavingMitigation}
+                            className="btn-primary flex items-center gap-1 px-3 py-1 text-sm"
+                          >
+                            {isSavingMitigation ? (
+                              <>
+                                <Loader2 size={14} className="animate-spin" />
+                                Saving...
+                              </>
+                            ) : (
+                              'Save'
+                            )}
+                          </button>
+                        </>
+                      ) : (
+                        <button
+                          onClick={handleStartEditMitigation}
+                          className="rounded-md px-3 py-1 text-sm transition-colors hover:bg-[var(--surface-hover)]"
+                          style={{ color: 'var(--primary)' }}
+                        >
+                          Edit
+                        </button>
+                      )}
+                    </div>
+                  )}
+                </div>
+                {isEditingMitigation ? (
+                  <textarea
+                    value={editMitigation}
+                    onChange={(e) => setEditMitigation(e.target.value)}
+                    className="input w-full text-sm"
+                    rows={3}
+                    placeholder="Enter mitigation..."
+                    autoFocus
+                  />
+                ) : ticket.mitigation ? (
+                  <div
+                    className="prose prose-sm prose-invert user-content max-w-none"
+                    style={{ color: 'var(--text-secondary)' }}
+                    dangerouslySetInnerHTML={{ __html: ticket.mitigation }}
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    className="text-sm italic"
+                    style={{
+                      color: 'var(--text-muted)',
+                      cursor: onMitigationChange ? 'pointer' : 'default',
+                    }}
+                    onClick={onMitigationChange ? handleStartEditMitigation : undefined}
+                  >
+                    No mitigation — click to add
                   </button>
                 )}
               </div>

--- a/src/components/tickets/WorkItemDetailContent.tsx
+++ b/src/components/tickets/WorkItemDetailContent.tsx
@@ -4,7 +4,11 @@ import { useState } from 'react';
 import { format } from 'date-fns';
 import { Pencil, Check, X, Loader2 } from 'lucide-react';
 import type { WorkItem, TicketComment } from '@/types';
-import { getTemplateConfig, hasResolutionField } from '@/config/process-templates';
+import {
+  getTemplateConfig,
+  hasMitigationField,
+  hasResolutionField,
+} from '@/config/process-templates';
 import Avatar from '../common/Avatar';
 import CommentSection from './CommentSection';
 import ZapDialog from './ZapDialog';
@@ -18,6 +22,7 @@ interface WorkItemDetailContentProps {
     title?: string;
     description?: string;
     resolution?: string;
+    mitigation?: string;
   }) => Promise<void>;
   onZapSent?: (amount: number) => void;
   showRequester?: boolean;
@@ -141,6 +146,114 @@ function ResolutionField({
   );
 }
 
+function MitigationField({
+  workItem,
+  onUpdate,
+}: {
+  workItem: WorkItem;
+  onUpdate?: (updates: { mitigation?: string }) => Promise<void>;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleStartEdit = () => {
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = workItem.mitigation || '';
+    setEditValue(tempDiv.textContent || tempDiv.innerText || '');
+    setIsEditing(true);
+  };
+
+  const handleSave = async () => {
+    if (!onUpdate) return;
+    setIsSaving(true);
+    try {
+      await onUpdate({ mitigation: editValue });
+      setIsEditing(false);
+    } catch (err) {
+      console.error('Failed to save mitigation:', err);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setEditValue('');
+  };
+
+  return (
+    <div className="card mt-4 p-4">
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="text-xs font-medium uppercase" style={{ color: 'var(--text-muted)' }}>
+          Mitigation
+        </h3>
+        {onUpdate && !isEditing && (
+          <button
+            onClick={handleStartEdit}
+            className="rounded p-1 transition-colors hover:bg-[var(--surface-hover)]"
+            title="Edit mitigation"
+          >
+            <Pencil size={12} style={{ color: 'var(--text-muted)' }} />
+          </button>
+        )}
+        {isEditing && (
+          <div className="flex items-center gap-1">
+            <button
+              onClick={handleSave}
+              disabled={isSaving}
+              className="rounded p-1 transition-colors hover:bg-[var(--surface-hover)]"
+              title="Save"
+            >
+              {isSaving ? (
+                <Loader2
+                  size={12}
+                  className="animate-spin"
+                  style={{ color: 'var(--text-muted)' }}
+                />
+              ) : (
+                <Check size={12} style={{ color: 'var(--primary)' }} />
+              )}
+            </button>
+            <button
+              onClick={handleCancel}
+              className="rounded p-1 transition-colors hover:bg-[var(--surface-hover)]"
+              title="Cancel"
+            >
+              <X size={12} style={{ color: 'var(--text-muted)' }} />
+            </button>
+          </div>
+        )}
+      </div>
+      {isEditing ? (
+        <textarea
+          value={editValue}
+          onChange={(e) => setEditValue(e.target.value)}
+          className="input w-full text-sm"
+          rows={3}
+          placeholder="Enter mitigation..."
+          autoFocus
+        />
+      ) : workItem.mitigation ? (
+        <div
+          className="prose prose-sm prose-invert user-content max-w-none"
+          style={{ color: 'var(--text-secondary)' }}
+          dangerouslySetInnerHTML={{ __html: workItem.mitigation }}
+        />
+      ) : (
+        <button
+          type="button"
+          className="text-sm italic"
+          style={{ color: 'var(--text-muted)', cursor: onUpdate ? 'pointer' : 'default' }}
+          onClick={onUpdate ? handleStartEdit : undefined}
+        >
+          No mitigation — click to add
+        </button>
+      )}
+    </div>
+  );
+}
+
 export default function WorkItemDetailContent({
   workItem,
   comments,
@@ -156,6 +269,7 @@ export default function WorkItemDetailContent({
   const [isZapDialogOpen, setIsZapDialogOpen] = useState(false);
   const templateConfig = getTemplateConfig(processTemplate);
   const showResolution = hasResolutionField(workItem.workItemType, templateConfig);
+  const showMitigation = hasMitigationField(workItem.workItemType, templateConfig);
 
   // Edit mode state
   const [isEditing, setIsEditing] = useState(false);
@@ -323,6 +437,7 @@ export default function WorkItemDetailContent({
 
       {/* Resolution (editable) - only for work item types that support it */}
       {showResolution && <ResolutionField workItem={workItem} onUpdate={onUpdate} />}
+      {showMitigation && <MitigationField workItem={workItem} onUpdate={onUpdate} />}
 
       {/* Effort tracking */}
       {showEffortTracking &&

--- a/src/components/tickets/WorkItemDetailContent.tsx
+++ b/src/components/tickets/WorkItemDetailContent.tsx
@@ -235,11 +235,9 @@ function MitigationField({
           autoFocus
         />
       ) : workItem.mitigation ? (
-        <div
-          className="prose prose-sm prose-invert user-content max-w-none"
-          style={{ color: 'var(--text-secondary)' }}
-          dangerouslySetInnerHTML={{ __html: workItem.mitigation }}
-        />
+        <p className="text-sm whitespace-pre-wrap" style={{ color: 'var(--text-secondary)' }}>
+          {workItem.mitigation}
+        </p>
       ) : (
         <button
           type="button"

--- a/src/config/process-templates/index.ts
+++ b/src/config/process-templates/index.ts
@@ -30,6 +30,8 @@ export interface ProcessTemplateConfig {
     priorityValues?: Record<number, string>; // Map numeric values to display names
     resolutionTypes?: string[]; // Work item types that support the Resolution field
     resolutionFieldOverrides?: Record<string, string>; // Per-type field ref overrides for Resolution
+    mitigationTypes?: string[]; // Work item types that support the Mitigation field
+    mitigationFieldOverrides?: Record<string, string>; // Per-type field ref overrides for Mitigation
   };
 
   // State mappings - map actual DevOps states to our UI categories
@@ -127,6 +129,7 @@ export function hasResolutionField(workItemType: string, config: ProcessTemplate
 }
 
 const DEFAULT_RESOLUTION_FIELD = 'Microsoft.VSTS.Common.Resolution';
+const DEFAULT_MITIGATION_FIELD = 'Microsoft.VSTS.CMMI.Mitigation';
 
 /**
  * Get the Azure DevOps field reference name for the Resolution field
@@ -134,6 +137,20 @@ const DEFAULT_RESOLUTION_FIELD = 'Microsoft.VSTS.Common.Resolution';
  */
 export function getResolutionFieldRef(workItemType: string, config: ProcessTemplateConfig): string {
   return config.fields.resolutionFieldOverrides?.[workItemType] ?? DEFAULT_RESOLUTION_FIELD;
+}
+
+/**
+ * Check if a work item type supports the Mitigation field in a given template
+ */
+export function hasMitigationField(workItemType: string, config: ProcessTemplateConfig): boolean {
+  return config.fields.mitigationTypes?.includes(workItemType) ?? false;
+}
+
+/**
+ * Get the Azure DevOps field reference name for the Mitigation field
+ */
+export function getMitigationFieldRef(workItemType: string, config: ProcessTemplateConfig): string {
+  return config.fields.mitigationFieldOverrides?.[workItemType] ?? DEFAULT_MITIGATION_FIELD;
 }
 
 /**

--- a/src/config/process-templates/t-minus-15.ts
+++ b/src/config/process-templates/t-minus-15.ts
@@ -33,6 +33,7 @@ export const tMinus15Config: ProcessTemplateConfig = {
     resolutionFieldOverrides: {
       Task: 'Custom.TaskResolution',
     },
+    mitigationTypes: ['Issue', 'Risk'],
   },
 
   states: {

--- a/src/lib/devops.ts
+++ b/src/lib/devops.ts
@@ -25,7 +25,11 @@ import type {
   ClassificationNode,
 } from '@/types';
 import { parseSLAFromDescription, calculateTicketSLA, DEFAULT_SLA_LEVEL } from './sla';
-import { getResolutionFieldRef, getTemplateConfig } from '@/config/process-templates';
+import {
+  getMitigationFieldRef,
+  getResolutionFieldRef,
+  getTemplateConfig,
+} from '@/config/process-templates';
 
 const DEVOPS_ORG = process.env.AZURE_DEVOPS_ORG || 'KnowAll';
 const DEVOPS_BASE_URL = `https://dev.azure.com/${DEVOPS_ORG}`;
@@ -37,6 +41,18 @@ const DEVOPS_BASE_URL = `https://dev.azure.com/${DEVOPS_ORG}`;
 function readResolutionField(fields: Record<string, unknown>): string | undefined {
   // Check standard field first, then known custom fields
   const candidates = ['Microsoft.VSTS.Common.Resolution', 'Custom.TaskResolution'];
+  for (const ref of candidates) {
+    const value = fields[ref] as string;
+    if (value) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Read the mitigation value from a work item (used by Issue/Risk types)
+ */
+function readMitigationField(fields: Record<string, unknown>): string | undefined {
+  const candidates = ['Microsoft.VSTS.CMMI.Mitigation', 'Custom.Mitigation'];
   for (const ref of candidates) {
     const value = fields[ref] as string;
     if (value) return value;
@@ -190,6 +206,7 @@ export function ticketToWorkItem(ticket: Ticket): WorkItem {
     tags: ticket.tags,
     priority: ticket.priority,
     resolution: ticket.resolution,
+    mitigation: ticket.mitigation,
     resolvedReason: ticket.resolvedReason,
     requester: ticket.requester,
     organization: ticket.organization,
@@ -207,6 +224,7 @@ export function workItemToTicket(workItem: DevOpsWorkItem, organization?: Organi
     reproSteps: (fields['Microsoft.VSTS.TCM.ReproSteps'] as string) || undefined,
     systemInfo: (fields['Microsoft.VSTS.TCM.SystemInfo'] as string) || undefined,
     resolution: readResolutionField(fields),
+    mitigation: readMitigationField(fields),
     resolvedReason: (fields['Microsoft.VSTS.Common.ResolvedReason'] as string) || undefined,
     status: mapStateToStatus(fields['System.State']),
     devOpsState: fields['System.State'], // Preserve original DevOps state
@@ -1178,6 +1196,7 @@ export class AzureDevOpsService {
       title?: string;
       description?: string;
       resolution?: string;
+      mitigation?: string;
       workItemType?: string;
     }
   ): Promise<DevOpsWorkItem> {
@@ -1242,6 +1261,29 @@ export class AzureDevOpsService {
         op: 'add',
         path: `/fields/${resFieldRef}`,
         value: updates.resolution,
+      });
+    }
+
+    if (updates.mitigation !== undefined) {
+      const templateConfig = getTemplateConfig();
+      let mitFieldRef = getMitigationFieldRef(updates.workItemType || '', templateConfig);
+
+      const standardMitField = 'Microsoft.VSTS.CMMI.Mitigation';
+      if (mitFieldRef !== standardMitField && updates.workItemType) {
+        try {
+          await this.getWorkItemTypeField(projectName, updates.workItemType, mitFieldRef);
+        } catch {
+          console.warn(
+            `Mitigation field ${mitFieldRef} not found on ${updates.workItemType}, falling back to ${standardMitField}`
+          );
+          mitFieldRef = standardMitField;
+        }
+      }
+
+      patchDocument.push({
+        op: 'add',
+        path: `/fields/${mitFieldRef}`,
+        value: updates.mitigation,
       });
     }
 
@@ -2134,6 +2176,7 @@ export class AzureDevOpsService {
           .filter(Boolean) || [],
       priority: mapPriority(fields['Microsoft.VSTS.Common.Priority']),
       resolution: readResolutionField(fields),
+      mitigation: readMitigationField(fields),
       resolvedReason: (fields['Microsoft.VSTS.Common.ResolvedReason'] as string) || undefined,
     };
   }

--- a/src/lib/devops.ts
+++ b/src/lib/devops.ts
@@ -50,10 +50,15 @@ function readResolutionField(fields: Record<string, unknown>): string | undefine
 
 /**
  * Read the mitigation value from a work item (used by Issue/Risk types)
+ * Checks the standard CMMI field, any template overrides, and known custom fields.
  */
 function readMitigationField(fields: Record<string, unknown>): string | undefined {
-  const candidates = ['Microsoft.VSTS.CMMI.Mitigation', 'Custom.Mitigation'];
-  for (const ref of candidates) {
+  const templateConfig = getTemplateConfig();
+  const overrides = Object.values(templateConfig.fields.mitigationFieldOverrides || {});
+  const candidates = ['Microsoft.VSTS.CMMI.Mitigation', ...overrides, 'Custom.Mitigation'];
+  // Deduplicate
+  const unique = [...new Set(candidates)];
+  for (const ref of unique) {
     const value = fields[ref] as string;
     if (value) return value;
   }
@@ -1264,27 +1269,40 @@ export class AzureDevOpsService {
       });
     }
 
-    if (updates.mitigation !== undefined) {
+    if (updates.mitigation !== undefined && updates.workItemType) {
       const templateConfig = getTemplateConfig();
-      let mitFieldRef = getMitigationFieldRef(updates.workItemType || '', templateConfig);
+      let mitFieldRef = getMitigationFieldRef(updates.workItemType, templateConfig);
 
-      const standardMitField = 'Microsoft.VSTS.CMMI.Mitigation';
-      if (mitFieldRef !== standardMitField && updates.workItemType) {
-        try {
-          await this.getWorkItemTypeField(projectName, updates.workItemType, mitFieldRef);
-        } catch {
+      // Always probe the field to ensure it exists on this work item type
+      try {
+        await this.getWorkItemTypeField(projectName, updates.workItemType, mitFieldRef);
+      } catch {
+        // Try the standard CMMI field as fallback
+        const standardMitField = 'Microsoft.VSTS.CMMI.Mitigation';
+        if (mitFieldRef !== standardMitField) {
           console.warn(
-            `Mitigation field ${mitFieldRef} not found on ${updates.workItemType}, falling back to ${standardMitField}`
+            `Mitigation field ${mitFieldRef} not found on ${updates.workItemType}, trying ${standardMitField}`
           );
-          mitFieldRef = standardMitField;
+          try {
+            await this.getWorkItemTypeField(projectName, updates.workItemType, standardMitField);
+            mitFieldRef = standardMitField;
+          } catch {
+            console.warn(`Mitigation field not available on ${updates.workItemType}`);
+            mitFieldRef = '';
+          }
+        } else {
+          console.warn(`Mitigation field not available on ${updates.workItemType}`);
+          mitFieldRef = '';
         }
       }
 
-      patchDocument.push({
-        op: 'add',
-        path: `/fields/${mitFieldRef}`,
-        value: updates.mitigation,
-      });
+      if (mitFieldRef) {
+        patchDocument.push({
+          op: 'add',
+          path: `/fields/${mitFieldRef}`,
+          value: updates.mitigation,
+        });
+      }
     }
 
     if (patchDocument.length === 0) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -148,6 +148,7 @@ export interface Ticket {
   reproSteps?: string;
   systemInfo?: string;
   resolution?: string;
+  mitigation?: string;
   resolvedReason?: string;
   status: TicketStatus;
   devOpsState: string; // Original Azure DevOps state (e.g., 'New', 'Approved', 'To Do', etc.)
@@ -491,6 +492,7 @@ export interface WorkItem {
   tags: string[];
   priority?: TicketPriority;
   resolution?: string;
+  mitigation?: string;
   resolvedReason?: string;
   // Optional ticket-specific fields (populated when item is a ticket)
   requester?: Customer;


### PR DESCRIPTION
## Summary
- Add mitigation field to Ticket and WorkItem types
- Add `mitigationTypes` config to process templates (Issue, Risk for T-Minus-15)
- Read/write `Microsoft.VSTS.CMMI.Mitigation` field from Azure DevOps with probe-and-fallback
- Add MitigationField component to WorkItemDetailContent (dialog view)
- Add inline mitigation editing to TicketDetail (full page view) with matching button styling
<img width="1491" height="679" alt="image" src="https://github.com/user-attachments/assets/de9e780c-4fcb-45c9-b903-b70c4a6f0bad" />

Closes #347

## Test plan
- [ ] Open an Issue or Risk work item — verify Mitigation section appears
- [ ] Click Edit on Mitigation — verify inline textarea editing works
- [ ] Save a mitigation value — verify it persists to Azure DevOps
- [ ] Open a Bug/Task/Enhancement — verify Mitigation does NOT appear
- [ ] Test in both dialog view and full page view

🤖 Generated with [Claude Code](https://claude.com/claude-code)