### PR TITLE
fix: Rename Kanban Board URL from /standup to /kanban

### DIFF
--- a/src/app/kanban/page.tsx
+++ b/src/app/kanban/page.tsx
@@ -13,13 +13,13 @@ import type { StandupData, StandupColumn, StandupWorkItem } from '@/types';
 
 type GroupBy = 'project' | 'person';
 
-/** Build /standup URL with the given params */
-function buildStandupUrl(groupBy: GroupBy, sprint: boolean): string {
+/** Build /kanban URL with the given params */
+function buildKanbanUrl(groupBy: GroupBy, sprint: boolean): string {
   const params = new URLSearchParams();
   if (groupBy !== 'project') params.set('groupBy', groupBy);
   if (sprint) params.set('sprint', 'true');
   const qs = params.toString();
-  return `/standup${qs ? `?${qs}` : ''}`;
+  return `/kanban${qs ? `?${qs}` : ''}`;
 }
 
 interface GroupData {
@@ -215,7 +215,7 @@ function StandupPageContent() {
               {/* Group By toggle */}
               <div className="flex rounded-md border" style={{ borderColor: 'var(--border)' }}>
                 <Link
-                  href={buildStandupUrl('project', currentSprintOnly)}
+                  href={buildKanbanUrl('project', currentSprintOnly)}
                   replace
                   className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors ${
                     groupBy === 'project'
@@ -228,7 +228,7 @@ function StandupPageContent() {
                   Project
                 </Link>
                 <Link
-                  href={buildStandupUrl('person', currentSprintOnly)}
+                  href={buildKanbanUrl('person', currentSprintOnly)}
                   replace
                   className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors ${
                     groupBy === 'person'
@@ -251,7 +251,7 @@ function StandupPageContent() {
                   type="checkbox"
                   checked={currentSprintOnly}
                   onChange={(e) =>
-                    router.replace(buildStandupUrl(groupBy, e.target.checked), { scroll: false })
+                    router.replace(buildKanbanUrl(groupBy, e.target.checked), { scroll: false })
                   }
                   className="accent-[var(--primary)]"
                 />

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -50,10 +50,10 @@ const mainNavItems = [
     href: '/reporting',
   },
   {
-    id: 'standup',
+    id: 'kanban',
     name: 'Kanban Board',
     icon: <ClipboardList size={20} />,
-    href: '/standup',
+    href: '/kanban',
   },
   {
     id: 'monthly-checkpoint',

--- a/src/components/tickets/WorkItemDetailContent.tsx
+++ b/src/components/tickets/WorkItemDetailContent.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { format } from 'date-fns';
-import { Check, X, Loader2 } from 'lucide-react';
+import { Pencil, Check, X, Loader2 } from 'lucide-react';
 import type { WorkItem, TicketComment } from '@/types';
 import {
   getTemplateConfig,


### PR DESCRIPTION
## Summary
- Rename route directory `src/app/standup/` to `src/app/kanban/` so the URL matches the page title
- Update sidebar link from `/standup` to `/kanban`
- Fix missing `Pencil` import in `WorkItemDetailContent.tsx` (pre-existing on main)

<img width="1082" height="618" alt="image" src="https://github.com/user-attachments/assets/40e96445-b901-4f91-92bf-ff581afccdcf" />

Closes #349

## Test plan
- [x] Navigate to Kanban Board from sidebar — URL should be `/kanban`
- [x] Group By and Sprint filter links use `/kanban` URLs
- [x] Old `/standup` URL no longer works (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)