### PR TITLE
feat: show project tag on Kanban board cards (#353)

### DIFF
--- a/src/components/standup/StandupKanbanCard.tsx
+++ b/src/components/standup/StandupKanbanCard.tsx
@@ -75,8 +75,8 @@ export default function StandupKanbanCard({ item, isDragging }: StandupKanbanCar
 
           {item.project && (
             <span
-              className="max-w-[110px] truncate rounded px-1.5 py-0.5 text-[10px] font-medium text-[var(--text-muted)]"
-              style={{ backgroundColor: 'var(--surface-hover)' }}
+              className="max-w-[110px] truncate rounded bg-[var(--surface-hover)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--text-muted)]"
+              aria-label={`Project: ${item.project}`}
               title={item.project}
             >
               {item.project}

--- a/src/components/standup/StandupKanbanCard.tsx
+++ b/src/components/standup/StandupKanbanCard.tsx
@@ -61,9 +61,9 @@ export default function StandupKanbanCard({ item, isDragging }: StandupKanbanCar
           {item.title}
         </h4>
 
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-2">
           {item.assignee ? (
-            <div className="flex items-center gap-1.5">
+            <div className="flex min-w-0 items-center gap-1.5">
               <Avatar name={item.assignee.displayName} image={item.assignee.avatarUrl} size="sm" />
               <span className="max-w-[100px] truncate text-xs text-[var(--text-secondary)]">
                 {item.assignee.displayName}
@@ -71,6 +71,16 @@ export default function StandupKanbanCard({ item, isDragging }: StandupKanbanCar
             </div>
           ) : (
             <span className="text-xs text-[var(--text-muted)] italic">Unassigned</span>
+          )}
+
+          {item.project && (
+            <span
+              className="max-w-[110px] truncate rounded px-1.5 py-0.5 text-[10px] font-medium text-[var(--text-muted)]"
+              style={{ backgroundColor: 'var(--surface-hover)' }}
+              title={item.project}
+            >
+              {item.project}
+            </span>
           )}
         </div>
       </Link>


### PR DESCRIPTION
## Summary
- Display the Azure DevOps project name as a small badge on each Kanban card (`StandupKanbanCard`) so users can identify a work item's project at a glance.
- Especially useful in the **group-by-person** view, where cards from multiple projects appear together.
- Uses `item.project` already populated by `/api/devops/standup` — no API or type changes.

Closes #353

## Screenshot
<img width="2971" height="1893" alt="image" src="https://github.com/user-attachments/assets/242d48a9-a1b2-4067-8f27-8d73504c2c85" />

## Test plan
- [x] Open `/kanban` with group-by = Project — each card shows its project badge
- [x] Switch to group-by = Person — cards across projects each show their project badge
- [x] Long project names are truncated (max-width 110px) with tooltip on hover
- [x] No regression in drag-and-drop or card click-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)