### PR TITLE
feat: add toast notifications for ticket field updates (#296)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "react-dom": "19.2.3",
         "react-tooltip": "^5.30.0",
         "recharts": "^3.6.0",
+        "sonner": "^2.0.7",
       },
       "devDependencies": {
         "@playwright/test": "^1.57.0",
@@ -1153,6 +1154,8 @@
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "react-activity-calendar": "^3.0.5",
     "react-dom": "19.2.3",
     "react-tooltip": "^5.30.0",
-    "recharts": "^3.6.0"
+    "recharts": "^3.6.0",
+    "sonner": "^2.0.7"
   },
   "devDependencies": {
     "@playwright/test": "^1.57.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { Toaster } from 'sonner';
 import SessionProvider from '@/components/providers/SessionProvider';
 import OrganizationProvider from '@/components/providers/OrganizationProvider';
 import './globals.css';
@@ -75,6 +76,7 @@ export default function RootLayout({
         <SessionProvider>
           <OrganizationProvider>{children}</OrganizationProvider>
         </SessionProvider>
+        <Toaster theme="dark" position="bottom-right" richColors closeButton />
       </body>
     </html>
   );

--- a/src/app/tickets/[id]/page.tsx
+++ b/src/app/tickets/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useSession } from 'next-auth/react';
 import { useRouter, useParams } from 'next/navigation';
 import { useEffect, useState, useCallback } from 'react';
+import { toast } from 'sonner';
 import { MainLayout } from '@/components/layout';
 import { LoadingSpinner } from '@/components/common';
 import { TicketDetail } from '@/components/tickets';
@@ -140,10 +141,13 @@ export default function TicketDetailPage() {
       });
 
       if (response.ok) {
-        await fetchTicket(); // Refresh comments
+        await fetchTicket();
+      } else {
+        toast.error('Failed to add comment');
       }
     } catch (error) {
       console.error('Failed to add comment:', error);
+      toast.error('Failed to add comment');
     }
   };
 
@@ -156,10 +160,14 @@ export default function TicketDetailPage() {
       });
 
       if (response.ok) {
-        await fetchTicket(); // Refresh ticket
+        await fetchTicket();
+        toast.success(`Status updated to "${newState}"`);
+      } else {
+        toast.error('Failed to update status');
       }
     } catch (error) {
       console.error('Failed to update state:', error);
+      toast.error('Failed to update status');
     }
   };
 
@@ -176,10 +184,14 @@ export default function TicketDetailPage() {
       });
 
       if (response.ok) {
-        await fetchTicket(); // Refresh ticket
+        await fetchTicket();
+        toast.success('Assignee updated');
+      } else {
+        toast.error('Failed to update assignee');
       }
     } catch (error) {
       console.error('Failed to update assignee:', error);
+      toast.error('Failed to update assignee');
     }
   };
 
@@ -196,10 +208,14 @@ export default function TicketDetailPage() {
       });
 
       if (response.ok) {
-        await fetchTicket(); // Refresh ticket
+        await fetchTicket();
+        toast.success('Priority updated');
+      } else {
+        toast.error('Failed to update priority');
       }
     } catch (error) {
       console.error('Failed to update priority:', error);
+      toast.error('Failed to update priority');
     }
   };
 
@@ -214,9 +230,13 @@ export default function TicketDetailPage() {
 
       if (response.ok) {
         await fetchTicket();
+        toast.success(`Type changed to "${newType}"`);
+      } else {
+        toast.error('Failed to change work item type');
       }
     } catch (error) {
       console.error('Failed to change work item type:', error);
+      toast.error('Failed to change work item type');
     }
   };
 
@@ -237,8 +257,10 @@ export default function TicketDetailPage() {
       }
 
       await fetchTicket();
+      toast.success('Description updated');
     } catch (error) {
       console.error('Failed to update description:', error);
+      toast.error('Failed to update description');
       throw error;
     }
   };
@@ -252,9 +274,11 @@ export default function TicketDetailPage() {
     });
     if (!response.ok) {
       const data = await response.json().catch(() => ({}));
+      toast.error(data.error || 'Failed to update tags');
       throw new Error(data.error || 'Failed to update tags');
     }
     await fetchTicket();
+    toast.success('Tags updated');
   };
 
   const handleResolutionChange = async (resolution: string) => {
@@ -275,8 +299,10 @@ export default function TicketDetailPage() {
       }
 
       await fetchTicket();
+      toast.success('Resolution updated');
     } catch (error) {
       console.error('Failed to update resolution:', error);
+      toast.error('Failed to update resolution');
       throw error;
     }
   };
@@ -299,8 +325,10 @@ export default function TicketDetailPage() {
       }
 
       await fetchTicket();
+      toast.success('Mitigation updated');
     } catch (error) {
       console.error('Failed to update mitigation:', error);
+      toast.error('Failed to update mitigation');
       throw error;
     }
   };

--- a/src/app/tickets/[id]/page.tsx
+++ b/src/app/tickets/[id]/page.tsx
@@ -139,12 +139,8 @@ export default function TicketDetailPage() {
         headers: orgHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({ comment }),
       });
-
-      if (response.ok) {
-        await fetchTicket();
-      } else {
-        toast.error('Failed to add comment');
-      }
+      if (!response.ok) throw new Error('Failed to add comment');
+      await fetchTicket();
     } catch (error) {
       console.error('Failed to add comment:', error);
       toast.error('Failed to add comment');
@@ -158,13 +154,9 @@ export default function TicketDetailPage() {
         headers: orgHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({ state: newState }),
       });
-
-      if (response.ok) {
-        await fetchTicket();
-        toast.success(`Status updated to "${newState}"`);
-      } else {
-        toast.error('Failed to update status');
-      }
+      if (!response.ok) throw new Error('Failed to update state');
+      await fetchTicket();
+      toast.success(`Status updated to "${newState}"`);
     } catch (error) {
       console.error('Failed to update state:', error);
       toast.error('Failed to update status');
@@ -182,13 +174,9 @@ export default function TicketDetailPage() {
           project: ticket.project,
         }),
       });
-
-      if (response.ok) {
-        await fetchTicket();
-        toast.success('Assignee updated');
-      } else {
-        toast.error('Failed to update assignee');
-      }
+      if (!response.ok) throw new Error('Failed to update assignee');
+      await fetchTicket();
+      toast.success('Assignee updated');
     } catch (error) {
       console.error('Failed to update assignee:', error);
       toast.error('Failed to update assignee');
@@ -206,13 +194,9 @@ export default function TicketDetailPage() {
           project: ticket.project,
         }),
       });
-
-      if (response.ok) {
-        await fetchTicket();
-        toast.success('Priority updated');
-      } else {
-        toast.error('Failed to update priority');
-      }
+      if (!response.ok) throw new Error('Failed to update priority');
+      await fetchTicket();
+      toast.success('Priority updated');
     } catch (error) {
       console.error('Failed to update priority:', error);
       toast.error('Failed to update priority');
@@ -227,13 +211,9 @@ export default function TicketDetailPage() {
         headers: orgHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({ type: newType, project: ticket.project, additionalFields }),
       });
-
-      if (response.ok) {
-        await fetchTicket();
-        toast.success(`Type changed to "${newType}"`);
-      } else {
-        toast.error('Failed to change work item type');
-      }
+      if (!response.ok) throw new Error('Failed to change work item type');
+      await fetchTicket();
+      toast.success(`Type changed to "${newType}"`);
     } catch (error) {
       console.error('Failed to change work item type:', error);
       toast.error('Failed to change work item type');
@@ -251,11 +231,7 @@ export default function TicketDetailPage() {
           project: ticket.project,
         }),
       });
-
-      if (!response.ok) {
-        throw new Error('Failed to update description');
-      }
-
+      if (!response.ok) throw new Error('Failed to update description');
       await fetchTicket();
       toast.success('Description updated');
     } catch (error) {
@@ -267,18 +243,23 @@ export default function TicketDetailPage() {
 
   const handleTagsChange = async (tags: string[]) => {
     if (!ticket) return;
-    const response = await fetch(`/api/devops/tickets/${ticketId}`, {
-      method: 'PATCH',
-      headers: orgHeaders({ 'Content-Type': 'application/json' }),
-      body: JSON.stringify({ tags, project: ticket.project }),
-    });
-    if (!response.ok) {
-      const data = await response.json().catch(() => ({}));
-      toast.error(data.error || 'Failed to update tags');
-      throw new Error(data.error || 'Failed to update tags');
+    try {
+      const response = await fetch(`/api/devops/tickets/${ticketId}`, {
+        method: 'PATCH',
+        headers: orgHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({ tags, project: ticket.project }),
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed to update tags');
+      }
+      await fetchTicket();
+      toast.success('Tags updated');
+    } catch (error) {
+      console.error('Failed to update tags:', error);
+      toast.error(error instanceof Error ? error.message : 'Failed to update tags');
+      throw error;
     }
-    await fetchTicket();
-    toast.success('Tags updated');
   };
 
   const handleResolutionChange = async (resolution: string) => {
@@ -293,11 +274,7 @@ export default function TicketDetailPage() {
           workItemType: ticket.workItemType,
         }),
       });
-
-      if (!response.ok) {
-        throw new Error('Failed to update resolution');
-      }
-
+      if (!response.ok) throw new Error('Failed to update resolution');
       await fetchTicket();
       toast.success('Resolution updated');
     } catch (error) {
@@ -319,11 +296,7 @@ export default function TicketDetailPage() {
           workItemType: ticket.workItemType,
         }),
       });
-
-      if (!response.ok) {
-        throw new Error('Failed to update mitigation');
-      }
-
+      if (!response.ok) throw new Error('Failed to update mitigation');
       await fetchTicket();
       toast.success('Mitigation updated');
     } catch (error) {

--- a/src/app/tickets/[id]/page.tsx
+++ b/src/app/tickets/[id]/page.tsx
@@ -141,9 +141,11 @@ export default function TicketDetailPage() {
       });
       if (!response.ok) throw new Error('Failed to add comment');
       await fetchTicket();
+      toast.success('Comment added');
     } catch (error) {
       console.error('Failed to add comment:', error);
       toast.error('Failed to add comment');
+      throw error;
     }
   };
 
@@ -160,6 +162,7 @@ export default function TicketDetailPage() {
     } catch (error) {
       console.error('Failed to update state:', error);
       toast.error('Failed to update status');
+      throw error;
     }
   };
 
@@ -180,6 +183,7 @@ export default function TicketDetailPage() {
     } catch (error) {
       console.error('Failed to update assignee:', error);
       toast.error('Failed to update assignee');
+      throw error;
     }
   };
 
@@ -200,6 +204,7 @@ export default function TicketDetailPage() {
     } catch (error) {
       console.error('Failed to update priority:', error);
       toast.error('Failed to update priority');
+      throw error;
     }
   };
 
@@ -211,12 +216,16 @@ export default function TicketDetailPage() {
         headers: orgHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({ type: newType, project: ticket.project, additionalFields }),
       });
-      if (!response.ok) throw new Error('Failed to change work item type');
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || data.message || 'Failed to change work item type');
+      }
       await fetchTicket();
       toast.success(`Type changed to "${newType}"`);
     } catch (error) {
       console.error('Failed to change work item type:', error);
-      toast.error('Failed to change work item type');
+      toast.error(error instanceof Error ? error.message : 'Failed to change work item type');
+      throw error;
     }
   };
 

--- a/src/app/tickets/page.tsx
+++ b/src/app/tickets/page.tsx
@@ -3,6 +3,7 @@
 import { useSession } from 'next-auth/react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState, Suspense, useCallback } from 'react';
+import { toast } from 'sonner';
 import { MainLayout } from '@/components/layout';
 import { LoadingSpinner } from '@/components/common';
 import { TicketList } from '@/components/tickets';
@@ -118,6 +119,7 @@ function TicketsPageContent() {
         });
 
         if (!response.ok) {
+          toast.error('Failed to update status');
           throw new Error('Failed to update state');
         }
 
@@ -125,6 +127,7 @@ function TicketsPageContent() {
         setTickets((prev) =>
           prev.map((t) => (t.id === ticketId ? { ...t, devOpsState: newState } : t))
         );
+        toast.success(`Status updated to "${newState}"`);
       } catch (error) {
         console.error('Failed to update ticket state:', error);
         throw error; // Re-throw so KanbanBoard can handle rollback
@@ -174,9 +177,11 @@ function TicketsPageContent() {
             prev && prev.id === updatedTicket.id ? updatedTicket : prev
           );
         }
+        toast.success('Assignee updated');
       } else {
         const errorData = await response.json().catch(() => ({}));
         console.error('Assignee change failed:', response.status, errorData);
+        toast.error('Failed to update assignee');
       }
     },
     [tickets, selectedOrganization]
@@ -203,9 +208,11 @@ function TicketsPageContent() {
             prev && prev.id === updatedTicket.id ? updatedTicket : prev
           );
         }
+        toast.success('Priority updated');
       } else {
         const errorData = await response.json().catch(() => ({}));
         console.error('Priority change failed:', response.status, errorData);
+        toast.error('Failed to update priority');
       }
     },
     [tickets, selectedOrganization]
@@ -238,9 +245,11 @@ function TicketsPageContent() {
           );
           setSelectedTicket((prev) => (prev ? { ...prev, workItemType: newType } : null));
         }
+        toast.success(`Type changed to "${newType}"`);
       } else {
         const errorData = await response.json().catch(() => ({}));
         console.error('Type change failed:', response.status, errorData);
+        toast.error('Failed to change work item type');
         throw new Error(errorData.error || 'Failed to update work item type');
       }
     },
@@ -267,10 +276,12 @@ function TicketsPageContent() {
       });
       if (!response.ok) {
         const data = await response.json().catch(() => ({}));
+        toast.error(data.error || 'Failed to update tags');
         throw new Error(data.error || 'Failed to update tags');
       }
       setTickets((prev) => prev.map((t) => (t.id === workItemId ? { ...t, tags } : t)));
       setSelectedTicket((prev) => (prev && prev.id === workItemId ? { ...prev, tags } : prev));
+      toast.success('Tags updated');
     },
     [tickets, selectedOrganization]
   );
@@ -319,7 +330,16 @@ function TicketsPageContent() {
               }
             : null
         );
+        const field = updates.title
+          ? 'Title'
+          : updates.description
+            ? 'Description'
+            : updates.resolution !== undefined
+              ? 'Resolution'
+              : 'Work item';
+        toast.success(`${field} updated`);
       } else {
+        toast.error('Failed to update work item');
         throw new Error('Failed to update work item');
       }
     },

--- a/src/app/tickets/page.tsx
+++ b/src/app/tickets/page.tsx
@@ -181,6 +181,7 @@ function TicketsPageContent() {
       } catch (error) {
         console.error('Failed to update assignee:', error);
         toast.error('Failed to update assignee');
+        throw error;
       }
     },
     [tickets, selectedOrganization]
@@ -216,6 +217,7 @@ function TicketsPageContent() {
       } catch (error) {
         console.error('Failed to update priority:', error);
         toast.error('Failed to update priority');
+        throw error;
       }
     },
     [tickets, selectedOrganization]

--- a/src/app/tickets/page.tsx
+++ b/src/app/tickets/page.tsx
@@ -117,19 +117,14 @@ function TicketsPageContent() {
           },
           body: JSON.stringify({ state: newState }),
         });
-
-        if (!response.ok) {
-          toast.error('Failed to update status');
-          throw new Error('Failed to update state');
-        }
-
-        // Update local state with the new DevOps state
+        if (!response.ok) throw new Error('Failed to update state');
         setTickets((prev) =>
           prev.map((t) => (t.id === ticketId ? { ...t, devOpsState: newState } : t))
         );
         toast.success(`Status updated to "${newState}"`);
       } catch (error) {
         console.error('Failed to update ticket state:', error);
+        toast.error('Failed to update status');
         throw error; // Re-throw so KanbanBoard can handle rollback
       }
     },
@@ -160,15 +155,20 @@ function TicketsPageContent() {
     async (workItemId: number, assigneeId: string | null) => {
       const ticket = tickets.find((t) => t.id === workItemId);
       if (!ticket || !selectedOrganization) return;
-      const response = await fetch(`/api/devops/tickets/${workItemId}`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-devops-org': selectedOrganization.accountName,
-        },
-        body: JSON.stringify({ assignee: assigneeId, project: ticket.project }),
-      });
-      if (response.ok) {
+      try {
+        const response = await fetch(`/api/devops/tickets/${workItemId}`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-devops-org': selectedOrganization.accountName,
+          },
+          body: JSON.stringify({ assignee: assigneeId, project: ticket.project }),
+        });
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          console.error('Assignee change failed:', response.status, errorData);
+          throw new Error('Failed to update assignee');
+        }
         const data = await response.json();
         const updatedTicket = data.ticket;
         if (updatedTicket) {
@@ -178,9 +178,8 @@ function TicketsPageContent() {
           );
         }
         toast.success('Assignee updated');
-      } else {
-        const errorData = await response.json().catch(() => ({}));
-        console.error('Assignee change failed:', response.status, errorData);
+      } catch (error) {
+        console.error('Failed to update assignee:', error);
         toast.error('Failed to update assignee');
       }
     },
@@ -191,15 +190,20 @@ function TicketsPageContent() {
     async (workItemId: number, priority: number) => {
       const ticket = tickets.find((t) => t.id === workItemId);
       if (!ticket || !selectedOrganization) return;
-      const response = await fetch(`/api/devops/tickets/${workItemId}`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-devops-org': selectedOrganization.accountName,
-        },
-        body: JSON.stringify({ priority, project: ticket.project }),
-      });
-      if (response.ok) {
+      try {
+        const response = await fetch(`/api/devops/tickets/${workItemId}`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-devops-org': selectedOrganization.accountName,
+          },
+          body: JSON.stringify({ priority, project: ticket.project }),
+        });
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          console.error('Priority change failed:', response.status, errorData);
+          throw new Error('Failed to update priority');
+        }
         const data = await response.json();
         const updatedTicket = data.ticket;
         if (updatedTicket) {
@@ -209,9 +213,8 @@ function TicketsPageContent() {
           );
         }
         toast.success('Priority updated');
-      } else {
-        const errorData = await response.json().catch(() => ({}));
-        console.error('Priority change failed:', response.status, errorData);
+      } catch (error) {
+        console.error('Failed to update priority:', error);
         toast.error('Failed to update priority');
       }
     },
@@ -222,15 +225,20 @@ function TicketsPageContent() {
     async (workItemId: number, newType: string, additionalFields?: Record<string, string>) => {
       const ticket = tickets.find((t) => t.id === workItemId);
       if (!ticket || !selectedOrganization) return;
-      const response = await fetch(`/api/devops/tickets/${workItemId}/type`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-devops-org': selectedOrganization.accountName,
-        },
-        body: JSON.stringify({ type: newType, project: ticket.project, additionalFields }),
-      });
-      if (response.ok) {
+      try {
+        const response = await fetch(`/api/devops/tickets/${workItemId}/type`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-devops-org': selectedOrganization.accountName,
+          },
+          body: JSON.stringify({ type: newType, project: ticket.project, additionalFields }),
+        });
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          console.error('Type change failed:', response.status, errorData);
+          throw new Error(errorData.error || 'Failed to update work item type');
+        }
         const data = await response.json();
         const updatedTicket = data.ticket;
         if (updatedTicket) {
@@ -246,11 +254,10 @@ function TicketsPageContent() {
           setSelectedTicket((prev) => (prev ? { ...prev, workItemType: newType } : null));
         }
         toast.success(`Type changed to "${newType}"`);
-      } else {
-        const errorData = await response.json().catch(() => ({}));
-        console.error('Type change failed:', response.status, errorData);
-        toast.error('Failed to change work item type');
-        throw new Error(errorData.error || 'Failed to update work item type');
+      } catch (error) {
+        console.error('Failed to change work item type:', error);
+        toast.error(error instanceof Error ? error.message : 'Failed to change work item type');
+        throw error;
       }
     },
     [tickets, selectedOrganization]
@@ -266,22 +273,27 @@ function TicketsPageContent() {
     async (workItemId: number, tags: string[]) => {
       const ticket = tickets.find((t) => t.id === workItemId);
       if (!ticket || !selectedOrganization) return;
-      const response = await fetch(`/api/devops/tickets/${workItemId}`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-devops-org': selectedOrganization.accountName,
-        },
-        body: JSON.stringify({ tags, project: ticket.project }),
-      });
-      if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        toast.error(data.error || 'Failed to update tags');
-        throw new Error(data.error || 'Failed to update tags');
+      try {
+        const response = await fetch(`/api/devops/tickets/${workItemId}`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-devops-org': selectedOrganization.accountName,
+          },
+          body: JSON.stringify({ tags, project: ticket.project }),
+        });
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({}));
+          throw new Error(data.error || 'Failed to update tags');
+        }
+        setTickets((prev) => prev.map((t) => (t.id === workItemId ? { ...t, tags } : t)));
+        setSelectedTicket((prev) => (prev && prev.id === workItemId ? { ...prev, tags } : prev));
+        toast.success('Tags updated');
+      } catch (error) {
+        console.error('Failed to update tags:', error);
+        toast.error(error instanceof Error ? error.message : 'Failed to update tags');
+        throw error;
       }
-      setTickets((prev) => prev.map((t) => (t.id === workItemId ? { ...t, tags } : t)));
-      setSelectedTicket((prev) => (prev && prev.id === workItemId ? { ...prev, tags } : prev));
-      toast.success('Tags updated');
     },
     [tickets, selectedOrganization]
   );
@@ -293,54 +305,40 @@ function TicketsPageContent() {
     ) => {
       const ticket = tickets.find((t) => t.id === workItemId);
       if (!ticket || !selectedOrganization) return;
-      const response = await fetch(`/api/devops/tickets/${workItemId}`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-devops-org': selectedOrganization.accountName,
-        },
-        body: JSON.stringify({
-          ...updates,
-          project: ticket.project,
-          workItemType: ticket.workItemType,
-        }),
-      });
-      if (response.ok) {
-        // Update local state
-        setTickets((prev) =>
-          prev.map((t) =>
-            t.id === workItemId
-              ? {
-                  ...t,
-                  ...(updates.title && { title: updates.title }),
-                  ...(updates.description && { description: updates.description }),
-                  ...(updates.resolution !== undefined && { resolution: updates.resolution }),
-                }
-              : t
-          )
+      try {
+        const response = await fetch(`/api/devops/tickets/${workItemId}`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-devops-org': selectedOrganization.accountName,
+          },
+          body: JSON.stringify({
+            ...updates,
+            project: ticket.project,
+            workItemType: ticket.workItemType,
+          }),
+        });
+        if (!response.ok) throw new Error('Failed to update work item');
+        const applied: Partial<Ticket> = {};
+        if (updates.title !== undefined) applied.title = updates.title;
+        if (updates.description !== undefined) applied.description = updates.description;
+        if (updates.resolution !== undefined) applied.resolution = updates.resolution;
+        setTickets((prev) => prev.map((t) => (t.id === workItemId ? { ...t, ...applied } : t)));
+        setSelectedTicket((prev) => (prev ? { ...prev, ...applied } : null));
+        const fieldLabels: Record<keyof typeof updates, string> = {
+          title: 'Title',
+          description: 'Description',
+          resolution: 'Resolution',
+        };
+        const changedKey = (Object.keys(updates) as Array<keyof typeof updates>).find(
+          (k) => updates[k] !== undefined
         );
-        // Update selected ticket in dialog
-        setSelectedTicket((prev) =>
-          prev
-            ? {
-                ...prev,
-                ...(updates.title && { title: updates.title }),
-                ...(updates.description && { description: updates.description }),
-                ...(updates.resolution !== undefined && { resolution: updates.resolution }),
-              }
-            : null
-        );
-        const field = updates.title
-          ? 'Title'
-          : updates.description
-            ? 'Description'
-            : updates.resolution !== undefined
-              ? 'Resolution'
-              : 'Work item';
+        const field = changedKey ? fieldLabels[changedKey] : 'Work item';
         toast.success(`${field} updated`);
-      } else {
+      } catch (error) {
+        console.error('Failed to update work item:', error);
         toast.error('Failed to update work item');
-        throw new Error('Failed to update work item');
+        throw error;
       }
     },
     [tickets, selectedOrganization]

--- a/src/app/tickets/page.tsx
+++ b/src/app/tickets/page.tsx
@@ -303,7 +303,12 @@ function TicketsPageContent() {
   const handleWorkItemUpdate = useCallback(
     async (
       workItemId: number,
-      updates: { title?: string; description?: string; resolution?: string }
+      updates: {
+        title?: string;
+        description?: string;
+        resolution?: string;
+        mitigation?: string;
+      }
     ) => {
       const ticket = tickets.find((t) => t.id === workItemId);
       if (!ticket || !selectedOrganization) return;
@@ -325,17 +330,19 @@ function TicketsPageContent() {
         if (updates.title !== undefined) applied.title = updates.title;
         if (updates.description !== undefined) applied.description = updates.description;
         if (updates.resolution !== undefined) applied.resolution = updates.resolution;
+        if (updates.mitigation !== undefined) applied.mitigation = updates.mitigation;
         setTickets((prev) => prev.map((t) => (t.id === workItemId ? { ...t, ...applied } : t)));
         setSelectedTicket((prev) => (prev ? { ...prev, ...applied } : null));
         const fieldLabels: Record<keyof typeof updates, string> = {
           title: 'Title',
           description: 'Description',
           resolution: 'Resolution',
+          mitigation: 'Mitigation',
         };
         const changedKey = (Object.keys(updates) as Array<keyof typeof updates>).find(
           (k) => updates[k] !== undefined
         );
-        const field = changedKey ? fieldLabels[changedKey] : 'Work item';
+        const field = (changedKey && fieldLabels[changedKey]) || 'Work item';
         toast.success(`${field} updated`);
       } catch (error) {
         console.error('Failed to update work item:', error);

--- a/src/components/tickets/WorkItemDetailDialog.tsx
+++ b/src/components/tickets/WorkItemDetailDialog.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
 import { ExternalLink, ChevronDown, Loader2, Maximize2 } from 'lucide-react';
 import type { WorkItem, TicketComment, Attachment } from '@/types';
 import StatusBadge from '../common/StatusBadge';
@@ -28,7 +29,7 @@ interface WorkItemDetailDialogProps {
   onTagsChange?: (workItemId: number, tags: string[]) => Promise<void>;
   onUpdate?: (
     workItemId: number,
-    updates: { title?: string; description?: string; resolution?: string }
+    updates: { title?: string; description?: string; resolution?: string; mitigation?: string }
   ) => Promise<void>;
 }
 
@@ -126,13 +127,24 @@ export default function WorkItemDetailDialog({
   const handleAddComment = useCallback(
     async (comment: string) => {
       if (!workItem || !hasOrganization) return;
-      const response = await fetchDevOps(`/api/devops/tickets/${workItem.id}/comments`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ comment }),
-      });
-      if (response.ok) {
+      try {
+        const response = await fetchDevOps(`/api/devops/tickets/${workItem.id}/comments`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ comment }),
+        });
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({}));
+          throw new Error(data.error || 'Failed to add comment');
+        }
         await fetchComments();
+        toast.success('Comment added');
+      } catch (error) {
+        // Re-throw so CommentSection keeps the unsent text in the input
+        // instead of clearing it on a silent failure.
+        console.error('Failed to add comment:', error);
+        toast.error(error instanceof Error ? error.message : 'Failed to add comment');
+        throw error;
       }
     },
     [workItem, fetchComments, fetchDevOps, hasOrganization]
@@ -158,7 +170,12 @@ export default function WorkItemDetailDialog({
   );
 
   const handleUpdate = useCallback(
-    async (updates: { title?: string; description?: string; resolution?: string }) => {
+    async (updates: {
+      title?: string;
+      description?: string;
+      resolution?: string;
+      mitigation?: string;
+    }) => {
       if (!workItem || !onUpdate) return;
       await onUpdate(workItem.id, updates);
     },


### PR DESCRIPTION
## Summary
- Install `sonner` toast library and add `<Toaster>` to the root layout (dark theme, bottom-right)
- Show success/error toast notifications when users update any ticket field: status, assignee, priority, type, description, tags, resolution, mitigation, and comments
- Toasts are wired in both the **ticket detail page** (`/tickets/[id]`) and the **ticket list dialog** (`/tickets`)

Fixes #296

## Screenshot
<img width="1576" height="787" alt="image" src="https://github.com/user-attachments/assets/157c239d-cd22-4660-9699-66e658a40637" />

## Test plan
- [x] Open a ticket and change status — verify success toast appears
- [x] Change assignee, priority, type — each shows a success toast
- [x] Edit description, resolution, mitigation — save triggers toast
- [x] Update tags — toast on add/remove
- [x] Force a failure (e.g. network off) — verify error toast appears
- [x] Open ticket from list view dialog (Kanban/list) — same toast behavior
- [x] No regressions in existing update functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)
