### PR TITLE
feat: color-code Epic state badges on Projects pages (#283)

### DIFF
--- a/src/app/projects/[id]/epics/[epicId]/page.tsx
+++ b/src/app/projects/[id]/epics/[epicId]/page.tsx
@@ -4,6 +4,7 @@ import { useSession } from 'next-auth/react';
 import { useRouter, useParams } from 'next/navigation';
 import { useEffect, useState, useCallback } from 'react';
 import { MainLayout } from '@/components/layout';
+import { StatusBadge } from '@/components/common';
 import { FeatureTimechain } from '@/components/visualization';
 import { ArrowLeft, ExternalLink, Loader2, LayoutGrid, RefreshCw } from 'lucide-react';
 import Link from 'next/link';
@@ -133,15 +134,7 @@ export default function EpicDetailPage() {
                 {epic.title}
               </h1>
               <span style={{ color: 'var(--text-muted)' }}>#{epic.id}</span>
-              <span
-                className="rounded px-2 py-0.5 text-xs font-medium"
-                style={{
-                  backgroundColor: 'var(--surface)',
-                  color: 'var(--text-secondary)',
-                }}
-              >
-                {epic.state}
-              </span>
+              <StatusBadge status={epic.state} />
             </div>
           </div>
           <div className="flex items-center gap-2">

--- a/src/app/projects/[id]/epics/page.tsx
+++ b/src/app/projects/[id]/epics/page.tsx
@@ -4,7 +4,7 @@ import { useSession } from 'next-auth/react';
 import { useRouter, useParams } from 'next/navigation';
 import { useEffect, useState, useCallback } from 'react';
 import { MainLayout } from '@/components/layout';
-import { LoadingSpinner } from '@/components/common';
+import { LoadingSpinner, StatusBadge } from '@/components/common';
 import { EpicTreemap } from '@/components/visualization';
 import {
   ArrowLeft,
@@ -235,7 +235,7 @@ export default function ProjectEpicsPage() {
                                 'Agile'
                               )}
                             </span>
-                            <span style={{ color: 'var(--text-muted)' }}>{epic.state}</span>
+                            <StatusBadge status={epic.state} size="sm" />
                           </div>
                         </div>
                         {selectedEpic?.id === epic.id && (

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useSession } from 'next-auth/react';
 import { useRouter, useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { MainLayout } from '@/components/layout';
-import { LoadingSpinner } from '@/components/common';
+import { LoadingSpinner, StatusBadge } from '@/components/common';
 import { ArrowLeft, ExternalLink, Loader2, Info, LayoutGrid } from 'lucide-react';
 import Link from 'next/link';
 import { format } from 'date-fns';
@@ -379,15 +379,7 @@ export default function ProjectDetailPage() {
                             >
                               {epic.title}
                             </h3>
-                            <span
-                              className="shrink-0 rounded px-2 py-0.5 text-xs font-medium"
-                              style={{
-                                backgroundColor: 'var(--surface)',
-                                color: 'var(--text-secondary)',
-                              }}
-                            >
-                              {epic.state}
-                            </span>
+                            <StatusBadge status={epic.state} size="sm" />
                           </div>
                           {epic.description && (
                             <p

--- a/src/components/common/StatusBadge.tsx
+++ b/src/components/common/StatusBadge.tsx
@@ -9,16 +9,20 @@ interface StatusBadgeProps {
 const stateConfig: Record<string, { label: string; className: string }> = {
   // Proposed states
   New: { label: 'New', className: 'status-new' },
+  Proposed: { label: 'Proposed', className: 'status-new' },
   Approved: { label: 'Approved', className: 'status-new' },
   'To Do': { label: 'To Do', className: 'status-new' },
   // InProgress states
   Active: { label: 'Active', className: 'status-in-progress' },
   'In Progress': { label: 'In Progress', className: 'status-in-progress' },
   Committed: { label: 'Committed', className: 'status-in-progress' },
+  Implementing: { label: 'Implementing', className: 'status-in-progress' },
   // Resolved/Completed states
   Resolved: { label: 'Resolved', className: 'status-resolved' },
+  Operate: { label: 'Operate', className: 'status-resolved' },
   Done: { label: 'Done', className: 'status-closed' },
   Closed: { label: 'Closed', className: 'status-closed' },
+  Completed: { label: 'Completed', className: 'status-closed' },
   // Other states
   Pending: { label: 'Pending', className: 'status-pending' },
   Open: { label: 'Open', className: 'status-open' },


### PR DESCRIPTION
## Summary
- Epic state was rendered as plain grey text/pill on the project detail, epics list, and epic detail pages. Now uses the shared `StatusBadge` so each state gets a distinct color — same treatment tickets already have.
- Extended `StatusBadge` with Epic-specific state names seen in the issue screenshot: `Implementing` (purple), `Operate` (green). Also added `Proposed` (blue) and `Completed` (gray) for coverage of common Agile/CMMI Epic workflows.
- Removed the hand-rolled `<span>` state chips in three places in favor of the shared component.
<img width="1558" height="834" alt="image" src="https://github.com/user-attachments/assets/24aa5edc-7997-4a14-8159-7fa35bb7c292" />


Fixes #283

## Test plan
- [x] Open `/projects/[id]` — each Epic card's state chip is colored by state
- [x] Open `/projects/[id]/epics` — sidebar Epic list shows colored `sm` badges
- [x] Open `/projects/[id]/epics/[epicId]` — header shows colored state badge
- [x] States seen in screenshot (`New`, `Implementing`, `Operate`) now visually distinct
- [x] Unknown/custom state names fall back to the orange default (unchanged)
- [x] No regression on ticket status badges elsewhere (same `StatusBadge` component)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
