### PR TITLE
feat: email channel — Graph mailbox polling for inbound tickets (#55)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,19 +21,32 @@ AZURE_DEVOPS_ORG=KnowAll
 AZURE_DEVOPS_PAT=your-personal-access-token-for-service-account
 
 # =============================================================================
-# Email Configuration (Exchange Online)
+# Email Configuration (Microsoft Graph)
 # =============================================================================
+# ZapDesk uses Microsoft Graph for both directions:
+#   - Outbound: client-credentials flow + Mail.Send to send replies
+#   - Inbound:  client-credentials flow + Mail.ReadWrite to poll the support
+#               mailbox every minute (no Power Automate / Logic App needed)
+#
+# Use a dedicated Azure AD app for mail (with Mail.Send + Mail.ReadWrite
+# Application permissions) and scope it to one mailbox via Exchange
+# Application Access Policy for least privilege. The app falls back to the
+# main AZURE_AD_* credentials if the MAIL_* ones aren't set.
 
-# Inbound Email Webhook
+# Shared secret protecting POST /api/email/poll and POST /api/email/webhook.
 EMAIL_WEBHOOK_SECRET=your-email-webhook-secret
 
-# Outbound Email (SMTP)
-SMTP_HOST=smtp.office365.com
-SMTP_PORT=587
-SMTP_USER=your-support-email@yourdomain.com
-SMTP_PASSWORD=your-app-password
-SMTP_FROM=your-support-email@yourdomain.com
-SMTP_FROM_NAME=ZapDesk Support
+# Mailbox ZapDesk polls for inbound mail (UPN or shared-mailbox SMTP address).
+MAIL_POLL_MAILBOX=support@yourdomain.com
+
+# Outbound sender — typically the same as MAIL_POLL_MAILBOX.
+MAIL_FROM=support@yourdomain.com
+MAIL_FROM_NAME=ZapDesk Support
+
+# Dedicated Azure AD app credentials for mail (recommended).
+MAIL_TENANT_ID=
+MAIL_CLIENT_ID=
+MAIL_CLIENT_SECRET=
 
 # =============================================================================
 # Email Routing Configuration

--- a/.github/workflows/email-poll.yml
+++ b/.github/workflows/email-poll.yml
@@ -1,0 +1,38 @@
+name: Poll support mailbox
+
+# Inbound email is fetched by polling the support mailbox via Microsoft Graph.
+# This workflow asks the deployed app to drain the mailbox once a minute. Each
+# unread message is turned into a ticket (or appended as a comment if it's a
+# reply to an existing one) and then marked as read.
+
+on:
+  schedule:
+    # GitHub Actions cron runs every 5 minutes minimum on free tiers, but the
+    # workflow accepts as low as '* * * * *' on paid plans. Adjust to taste.
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+
+# Don't queue concurrent runs — if a poll is slow, skip the next tick rather
+# than pile up. Cancel in-progress lets `workflow_dispatch` always run fresh.
+concurrency:
+  group: email-poll
+  cancel-in-progress: false
+
+jobs:
+  poll:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Drain support mailbox
+        env:
+          BASE_URL: ${{ secrets.ZAPDESK_BASE_URL }}
+          SECRET: ${{ secrets.EMAIL_WEBHOOK_SECRET }}
+        run: |
+          if [ -z "$BASE_URL" ] || [ -z "$SECRET" ]; then
+            echo "::error::ZAPDESK_BASE_URL and EMAIL_WEBHOOK_SECRET secrets must be configured."
+            exit 1
+          fi
+          response=$(curl -fsSL -X POST "${BASE_URL%/}/api/email/poll" \
+            -H "x-webhook-secret: $SECRET" \
+            --max-time 90)
+          echo "$response"

--- a/.github/workflows/email-poll.yml
+++ b/.github/workflows/email-poll.yml
@@ -12,11 +12,12 @@ on:
     - cron: '*/5 * * * *'
   workflow_dispatch:
 
-# Don't queue concurrent runs — if a poll is slow, skip the next tick rather
-# than pile up. Cancel in-progress lets `workflow_dispatch` always run fresh.
+# Don't queue concurrent runs — if a poll is slow, cancel it so the next tick
+# starts fresh and `workflow_dispatch` always runs against the latest state
+# rather than queueing behind a hung scheduled run.
 concurrency:
   group: email-poll
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   poll:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,13 @@ When making changes:
 | `AZURE_AD_TENANT_ID`                      | Azure AD tenant ID (or 'common')                 | Yes                   |
 | `AZURE_DEVOPS_ORG`                        | Azure DevOps organization name                   | Yes                   |
 | `AZURE_DEVOPS_PAT`                        | Personal Access Token for service account        | For email integration |
-| `EMAIL_WEBHOOK_SECRET`                    | Secret for email webhook authentication          | For email integration |
+| `EMAIL_WEBHOOK_SECRET`                    | Shared secret for `/api/email/poll` and `/api/email/webhook` | For email integration |
+| `MAIL_POLL_MAILBOX`                       | Mailbox ZapDesk polls for inbound email          | For inbound email     |
+| `MAIL_FROM`                               | Sender address for outbound mail                 | For outbound email    |
+| `MAIL_FROM_NAME`                          | Display name for outbound mail                   | No (default: ZapDesk Support) |
+| `MAIL_TENANT_ID`                          | Tenant ID for the dedicated mail Azure AD app    | For email integration |
+| `MAIL_CLIENT_ID`                          | Client ID for the dedicated mail Azure AD app    | For email integration |
+| `MAIL_CLIENT_SECRET`                      | Client secret for the dedicated mail Azure AD app | For email integration |
 | `TEAM_THRESHOLD_NEEDS_ATTENTION_PENDING`  | Pending tickets threshold for "Needs Attention"  | No (default: 5)       |
 | `TEAM_THRESHOLD_NEEDS_ATTENTION_ASSIGNED` | Assigned tickets threshold for "Needs Attention" | No (default: 15)      |
 | `TEAM_THRESHOLD_BEHIND_PENDING`           | Pending tickets threshold for "Behind"           | No (default: 2)       |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,26 +186,26 @@ When making changes:
 
 ## Environment Variables
 
-| Variable                                  | Description                                      | Required              |
-| ----------------------------------------- | ------------------------------------------------ | --------------------- |
-| `NEXTAUTH_URL`                            | Base URL of the application                      | Yes                   |
-| `NEXTAUTH_SECRET`                         | Secret for NextAuth encryption                   | Yes                   |
-| `AZURE_AD_CLIENT_ID`                      | Azure AD application client ID                   | Yes                   |
-| `AZURE_AD_CLIENT_SECRET`                  | Azure AD application client secret               | Yes                   |
-| `AZURE_AD_TENANT_ID`                      | Azure AD tenant ID (or 'common')                 | Yes                   |
-| `AZURE_DEVOPS_ORG`                        | Azure DevOps organization name                   | Yes                   |
-| `AZURE_DEVOPS_PAT`                        | Personal Access Token for service account        | For email integration |
-| `EMAIL_WEBHOOK_SECRET`                    | Shared secret for `/api/email/poll` and `/api/email/webhook` | For email integration |
-| `MAIL_POLL_MAILBOX`                       | Mailbox ZapDesk polls for inbound email          | For inbound email     |
-| `MAIL_FROM`                               | Sender address for outbound mail                 | For outbound email    |
-| `MAIL_FROM_NAME`                          | Display name for outbound mail                   | No (default: ZapDesk Support) |
-| `MAIL_TENANT_ID`                          | Tenant ID for the dedicated mail Azure AD app    | For email integration |
-| `MAIL_CLIENT_ID`                          | Client ID for the dedicated mail Azure AD app    | For email integration |
-| `MAIL_CLIENT_SECRET`                      | Client secret for the dedicated mail Azure AD app | For email integration |
-| `TEAM_THRESHOLD_NEEDS_ATTENTION_PENDING`  | Pending tickets threshold for "Needs Attention"  | No (default: 5)       |
-| `TEAM_THRESHOLD_NEEDS_ATTENTION_ASSIGNED` | Assigned tickets threshold for "Needs Attention" | No (default: 15)      |
-| `TEAM_THRESHOLD_BEHIND_PENDING`           | Pending tickets threshold for "Behind"           | No (default: 2)       |
-| `TEAM_THRESHOLD_BEHIND_ASSIGNED`          | Assigned tickets threshold for "Behind"          | No (default: 10)      |
+| Variable                                  | Description                                                  | Required                      |
+| ----------------------------------------- | ------------------------------------------------------------ | ----------------------------- |
+| `NEXTAUTH_URL`                            | Base URL of the application                                  | Yes                           |
+| `NEXTAUTH_SECRET`                         | Secret for NextAuth encryption                               | Yes                           |
+| `AZURE_AD_CLIENT_ID`                      | Azure AD application client ID                               | Yes                           |
+| `AZURE_AD_CLIENT_SECRET`                  | Azure AD application client secret                           | Yes                           |
+| `AZURE_AD_TENANT_ID`                      | Azure AD tenant ID (or 'common')                             | Yes                           |
+| `AZURE_DEVOPS_ORG`                        | Azure DevOps organization name                               | Yes                           |
+| `AZURE_DEVOPS_PAT`                        | Personal Access Token for service account                    | For email integration         |
+| `EMAIL_WEBHOOK_SECRET`                    | Shared secret for `/api/email/poll` and `/api/email/webhook` | For email integration         |
+| `MAIL_POLL_MAILBOX`                       | Mailbox ZapDesk polls for inbound email                      | For inbound email             |
+| `MAIL_FROM`                               | Sender address for outbound mail                             | For outbound email            |
+| `MAIL_FROM_NAME`                          | Display name for outbound mail                               | No (default: ZapDesk Support) |
+| `MAIL_TENANT_ID`                          | Tenant ID for the dedicated mail Azure AD app                | For email integration         |
+| `MAIL_CLIENT_ID`                          | Client ID for the dedicated mail Azure AD app                | For email integration         |
+| `MAIL_CLIENT_SECRET`                      | Client secret for the dedicated mail Azure AD app            | For email integration         |
+| `TEAM_THRESHOLD_NEEDS_ATTENTION_PENDING`  | Pending tickets threshold for "Needs Attention"              | No (default: 5)               |
+| `TEAM_THRESHOLD_NEEDS_ATTENTION_ASSIGNED` | Assigned tickets threshold for "Needs Attention"             | No (default: 15)              |
+| `TEAM_THRESHOLD_BEHIND_PENDING`           | Pending tickets threshold for "Behind"                       | No (default: 2)               |
+| `TEAM_THRESHOLD_BEHIND_ASSIGNED`          | Assigned tickets threshold for "Behind"                      | No (default: 10)              |
 
 ## Deployment
 

--- a/docs/EMAIL_SETUP.adoc
+++ b/docs/EMAIL_SETUP.adoc
@@ -1,206 +1,156 @@
-= ZapDesk Email Integration Setup
+= ZapDesk Email Channel Setup
 :toc: left
 :toclevels: 3
 :icons: font
 
 == Overview
 
-ZapDesk integrates with Exchange Online to provide:
+ZapDesk turns inbound email into Azure DevOps work items and emails the
+requester back when an agent replies or the ticket status changes.
 
-* **Inbound**: Customers email your configured support mailbox to create tickets
-* **Outbound**: Agent replies are emailed to the ticket requester
+* *Inbound*: a 1-minute cron polls the support mailbox via Microsoft Graph,
+  ingests each unread message, then marks it as read.
+* *Outbound*: confirmations, agent replies, and status-change notifications go
+  out via Microsoft Graph `sendMail` from the same support mailbox.
 
-== Exchange Online Configuration
+----
+Customer ──email──> support@yourdomain.com (Exchange Online)
+                         ↑
+                         │  Graph poll every minute
+                         │
+ZapDesk /api/email/poll ─┘
+       │
+       ├─ subject contains [ZapDesk #N]?
+       │     yes → add comment to ticket #N
+       │     no  → create ticket; route to project by sender domain
+       │
+       └─ Graph sendMail → Customer (confirmation / reply)
+----
 
-=== Create Shared Mailbox
+== Azure AD App for Mail
 
-1. Go to Microsoft 365 Admin Center
-2. Navigate to Teams & Groups > Shared mailboxes
-3. Click "Add a shared mailbox"
-4. Set display name: "ZapDesk Support"
-5. Set email: your-support-email@yourdomain.com
-6. Click "Create"
+Create or reuse one Azure AD app with these *Application* permissions:
 
-=== Enable SMTP Authentication
+[cols="1,2"]
+|===
+|Permission |Why
 
-SMTP AUTH is disabled by default for new mailboxes:
+|`Mail.Send`
+|Outbound — confirmations, agent replies, status updates
+
+|`Mail.ReadWrite`
+|Inbound — list unread mail and flag-as-read after processing
+|===
+
+[IMPORTANT]
+====
+Click *Grant admin consent* after adding the permissions. Without consent the
+client-credentials token request will succeed but every Graph call will return
+403.
+====
+
+=== Restrict to a single mailbox
+
+`Mail.Send` and `Mail.ReadWrite` Application give the app access to *every*
+mailbox in the tenant. Restrict it to the support mailbox only via an
+{empty}https://learn.microsoft.com/graph/auth-limit-mailbox-access[Application
+Access Policy^]:
 
 [source,powershell]
 ----
-# Connect to Exchange Online
 Connect-ExchangeOnline
 
-# Enable SMTP AUTH for the mailbox
-Set-CASMailbox -Identity "your-support-email@yourdomain.com" -SmtpClientAuthenticationDisabled $false
+# Replace <APP_ID> with the Azure AD client ID of the mail app
+New-ApplicationAccessPolicy `
+  -AppId <APP_ID> `
+  -PolicyScopeGroupId support@yourdomain.com `
+  -AccessRight RestrictAccess `
+  -Description "ZapDesk inbound + outbound — restricted to support mailbox"
 
 # Verify
-Get-CASMailbox -Identity "your-support-email@yourdomain.com" | Select SmtpClientAuthenticationDisabled
+Test-ApplicationAccessPolicy -Identity support@yourdomain.com -AppId <APP_ID>
+# Expected: AccessCheckResult = Granted
 ----
 
-=== Create App Password (Basic Auth)
+To cover multiple mailboxes later, create a mail-enabled security group
+containing them and pass the group address as `-PolicyScopeGroupId`.
 
-If using basic authentication:
-
-1. Sign in as a user with access to the shared mailbox
-2. Go to https://mysignins.microsoft.com/security-info
-3. Click "Add sign-in method" > "App password"
-4. Name it "ZapDesk SMTP"
-5. Copy the generated password
-
-=== Configure OAuth (Recommended)
-
-For production, use OAuth instead of basic auth:
-
-1. Register application in Azure AD
-2. Add Mail.Send permission
-3. Configure client credentials flow
-4. Use Microsoft Graph API for sending
-
-== Inbound Email Processing
-
-=== Option 1: Power Automate
-
-Create a Power Automate flow:
-
-1. **Trigger**: "When a new email arrives (V3)"
-   - Folder: Inbox
-   - To: your-support-email@yourdomain.com
-
-2. **Action**: "HTTP"
-   - Method: POST
-   - URI: https://zapdesk.yourdomain.com/api/email/webhook
-   - Headers:
-     - x-webhook-secret: <EMAIL_WEBHOOK_SECRET>
-   - Body:
-   ```json
-   {
-     "from": "@{triggerOutputs()?['body/from']}",
-     "to": "@{triggerOutputs()?['body/toRecipients']}",
-     "subject": "@{triggerOutputs()?['body/subject']}",
-     "body": "@{triggerOutputs()?['body/body']}"
-   }
-   ```
-
-=== Option 2: Mail Flow Rules
-
-For advanced routing, use Exchange transport rules:
-
-1. Go to Exchange Admin Center
-2. Navigate to Mail flow > Rules
-3. Create rule to redirect to webhook endpoint via connector
-
-=== Option 3: Azure Logic Apps
-
-Similar to Power Automate but with more control:
-
-1. Create Logic App in Azure
-2. Add Office 365 Outlook connector
-3. Add HTTP action for webhook
-
-== Outbound Email Processing
-
-=== Environment Variables
-
-Add to `.env`:
+== Environment Variables
 
 [source,env]
 ----
-# SMTP Configuration (Basic Auth)
-SMTP_HOST=smtp.office365.com
-SMTP_PORT=587
-SMTP_USER=your-support-email@yourdomain.com
-SMTP_PASSWORD=<app-password>
-SMTP_FROM=your-support-email@yourdomain.com
-SMTP_FROM_NAME=ZapDesk Support
+# Auth for the poll + webhook endpoints
+EMAIL_WEBHOOK_SECRET=<random ≥32 chars>
 
-# Or OAuth Configuration
-SMTP_OAUTH_CLIENT_ID=<client-id>
-SMTP_OAUTH_CLIENT_SECRET=<client-secret>
-SMTP_OAUTH_TENANT_ID=<tenant-id>
+# Mailbox ZapDesk polls for inbound mail
+MAIL_POLL_MAILBOX=support@yourdomain.com
+
+# Outbound sender (usually the same mailbox)
+MAIL_FROM=support@yourdomain.com
+MAIL_FROM_NAME=ZapDesk Support
+
+# Dedicated mail app credentials
+MAIL_TENANT_ID=<tenant id>
+MAIL_CLIENT_ID=<app id>
+MAIL_CLIENT_SECRET=<client secret>
+
+# Service account PAT used to create work items (already required for ZapDesk)
+AZURE_DEVOPS_PAT=<pat with Work Items Read & Write>
 ----
 
-=== Email Templates
+If the dedicated mail credentials are not set, ZapDesk falls back to the main
+`AZURE_AD_*` app — but the main app should not have `Mail.*` permissions in
+production, so configure the dedicated ones.
 
-Outbound emails include:
+== Project Routing by Sender Domain
 
-* Ticket reference number for threading
-* Link back to ticket in ZapDesk
-* Requester's original message (quoted)
-* Agent's response
+When a new message arrives, ZapDesk extracts the sender's email domain and
+looks for an Azure DevOps project whose description contains that domain. The
+ticket is created in the matched project.
 
-Example format:
+To route mail from `acme.com` to a project, add the domain to that project's
+description in Azure DevOps:
+
 ----
-Subject: Re: [ZapDesk #123] Original Subject
-
-Hi {RequesterName},
-
-{AgentResponse}
-
----
-Ticket: #123
-Status: {Status}
-View online: https://zapdesk.yourdomain.com/tickets/123
-
---- Original Message ---
-{OriginalMessage}
+Customer support project for Acme. Email: acme.com
 ----
+
+Multiple domains can be listed comma-separated. The mapping is cached for
+~5 minutes; descriptions can be edited at any time.
+
+== GitHub Actions Cron
+
+ZapDesk drives the mailbox poll from a workflow at
+`.github/workflows/email-poll.yml`. Set these *repository* secrets so the
+workflow can call the deployed app:
+
+[cols="1,2"]
+|===
+|Secret |Value
+
+|`ZAPDESK_BASE_URL`
+|e.g. `https://zapdesk.yourdomain.com`
+
+|`EMAIL_WEBHOOK_SECRET`
+|Same value used by the deployed app
+|===
+
+The workflow runs on a 5-minute schedule by default; tighten the cron
+expression to `* * * * *` if you need lower latency.
 
 == Email Threading
 
-Emails are threaded using:
+Subject prefix is the source of truth: every outbound email from ZapDesk
+contains `[ZapDesk #<id>]`, and inbound mail with that prefix is appended to
+the existing ticket as a comment instead of creating a new one. This works
+across every email client, no custom Message-ID handling required.
 
-* Subject prefix: `[ZapDesk #123]`
-* In-Reply-To header
-* References header
-* Message-ID stored in DevOps work item
+== Security
 
-== Security Considerations
-
-=== Inbound
-
-* Webhook protected by shared secret
-* Validate sender domain for project mapping
-* Rate limiting recommended
-* Attachment scanning (future)
-
-=== Outbound
-
-* Use TLS for SMTP connection
-* OAuth preferred over basic auth
-* App passwords expire - monitor and rotate
-* Log all outbound emails
-
-== Testing
-
-=== Test Inbound
-
-[source,bash]
-----
-curl -X POST https://zapdesk.yourdomain.com/api/email/webhook \
-  -H "Content-Type: application/json" \
-  -H "x-webhook-secret: your-secret" \
-  -d '{
-    "from": "test@cairnhomes.com",
-    "to": "your-support-email@yourdomain.com",
-    "subject": "Test ticket",
-    "body": "This is a test"
-  }'
-----
-
-=== Test Outbound
-
-[source,bash]
-----
-# Via ZapDesk UI
-1. Open a ticket
-2. Add a reply
-3. Check requester's inbox
-
-# Via API
-curl -X POST https://zapdesk.yourdomain.com/api/devops/tickets/123/reply \
-  -H "Authorization: Bearer <token>" \
-  -d '{"message": "Test reply"}'
-----
+* Webhook + poll endpoints authenticated with a shared secret (`x-webhook-secret`)
+* Sender domain validated against project mappings — unknown domains rejected
+* Internal notes (`[Internal Note] ...`) are never emailed to the customer
+* Mail app scope restricted to one mailbox via Application Access Policy
 
 == Troubleshooting
 
@@ -208,18 +158,24 @@ curl -X POST https://zapdesk.yourdomain.com/api/devops/tickets/123/reply \
 |===
 |Issue |Solution
 
-|Emails not creating tickets
-|Check webhook secret, sender domain mapping, server logs
+|Poll returns `401 Invalid webhook secret`
+|`EMAIL_WEBHOOK_SECRET` mismatch between the GitHub secret and App Service.
 
-|Replies not sending
-|Verify SMTP credentials, check Exchange Online auth policy
+|Poll returns `MAIL_POLL_MAILBOX not configured`
+|Set the `MAIL_POLL_MAILBOX` env var on App Service and restart.
 
-|Threading not working
-|Ensure Message-ID stored, check subject prefix format
+|Graph returns 403 on list / sendMail
+|`Mail.ReadWrite` / `Mail.Send` not granted with admin consent on the mail app, or the Application Access Policy is excluding the mailbox.
 
-|Attachments missing
-|Attachment processing not yet implemented
+|Emails create tickets in the wrong project
+|Project description missing or contains the wrong domain. Edit the description in DevOps; the cache refreshes within ~5 minutes.
 
-|Rate limited
-|Contact Microsoft support, implement retry logic
+|Replies create new tickets instead of comments
+|Customer's mail client stripped `[ZapDesk #N]` from the subject — check the rendered subject in the customer's reply.
+
+|Confirmations not arriving
+|Outbound mail unconfigured, or the sender mailbox is restricted by the Application Access Policy.
+
+|Same email creates two tickets
+|`mark-as-read` failed after a successful ingest. Inspect server logs for `failed to mark … read`. The mailbox can be safely cleaned up; future polls will continue normally.
 |===

--- a/scripts/check-domain-mapping.ts
+++ b/scripts/check-domain-mapping.ts
@@ -1,0 +1,54 @@
+/**
+ * Quick diagnostic: which DevOps projects map a given email domain?
+ * Run with:  bun scripts/check-domain-mapping.ts <domain>
+ */
+
+const domain = (process.argv[2] || '').toLowerCase().trim();
+if (!domain) {
+  console.error('Usage: bun scripts/check-domain-mapping.ts <domain>');
+  process.exit(1);
+}
+
+const pat = process.env.AZURE_DEVOPS_PAT;
+const org = process.env.AZURE_DEVOPS_ORG;
+if (!pat || !org) {
+  console.error('AZURE_DEVOPS_PAT and AZURE_DEVOPS_ORG must be set in .env.local');
+  process.exit(1);
+}
+
+const auth = 'Basic ' + Buffer.from(':' + pat).toString('base64');
+const res = await fetch(
+  `https://dev.azure.com/${org}/_apis/projects?api-version=7.0&$top=500&stateFilter=wellFormed`,
+  { headers: { Authorization: auth } }
+);
+if (!res.ok) {
+  console.error(`DevOps list-projects failed: ${res.status} ${await res.text()}`);
+  process.exit(1);
+}
+const data = (await res.json()) as { value: Array<{ name: string; description?: string }> };
+
+const matches = data.value.filter((p) => {
+  if (!p.description) return false;
+  // Mirror src/lib/devops.ts parsing: looks for "Email: a.com, b.com" or "email=a.com"
+  const m = p.description.match(/email[:\s=]+([\w.,\s-]+)/i);
+  if (!m) return false;
+  const domains = m[1]
+    .split(/[,;\s]+/)
+    .map((d) => d.trim().toLowerCase())
+    .filter(Boolean);
+  return domains.includes(domain);
+});
+
+console.log(`Searched ${data.value.length} projects for domain "${domain}":`);
+if (matches.length === 0) {
+  console.log('  (none — add `Email: ' + domain + '` to a project description in DevOps)');
+  // Help debugging: show any project whose description even mentions "email" so the user
+  // can spot a typo in an existing mapping.
+  const partial = data.value.filter((p) => p.description && /email/i.test(p.description));
+  if (partial.length > 0) {
+    console.log('\nProjects that mention "email" in their description (for reference):');
+    for (const p of partial) console.log(`  • ${p.name}: ${p.description}`);
+  }
+} else {
+  for (const p of matches) console.log(`  ✓ ${p.name}: ${p.description}`);
+}

--- a/scripts/check-mailbox-access.ts
+++ b/scripts/check-mailbox-access.ts
@@ -1,0 +1,81 @@
+/**
+ * Sanity check: can the mail app actually read + send for a given mailbox?
+ * This catches Application Access Policy gaps before we redirect the poller.
+ *
+ * Usage: bun scripts/check-mailbox-access.ts <mailbox>
+ */
+
+const mailbox = process.argv[2];
+if (!mailbox) {
+  console.error('Usage: bun scripts/check-mailbox-access.ts <mailbox>');
+  process.exit(1);
+}
+
+const tenant = process.env.MAIL_TENANT_ID || process.env.AZURE_AD_TENANT_ID;
+const clientId = process.env.MAIL_CLIENT_ID || process.env.AZURE_AD_CLIENT_ID;
+const clientSecret = process.env.MAIL_CLIENT_SECRET || process.env.AZURE_AD_CLIENT_SECRET;
+if (!tenant || !clientId || !clientSecret) {
+  console.error('MAIL_TENANT_ID / MAIL_CLIENT_ID / MAIL_CLIENT_SECRET must be set in .env.local');
+  process.exit(1);
+}
+
+const tokenRes = await fetch(`https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+  body: new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    grant_type: 'client_credentials',
+    scope: 'https://graph.microsoft.com/.default',
+  }),
+});
+const tokenJson = await tokenRes.json();
+if (!tokenRes.ok) {
+  console.error('❌ Token request failed:', JSON.stringify(tokenJson, null, 2));
+  process.exit(1);
+}
+const token = tokenJson.access_token;
+console.log('✓ Token acquired');
+
+// Read access — list one inbox message
+const readUrl =
+  `https://graph.microsoft.com/v1.0/users/${encodeURIComponent(mailbox)}/mailFolders('Inbox')/messages` +
+  `?$top=1&$select=id,subject`;
+const readRes = await fetch(readUrl, { headers: { Authorization: `Bearer ${token}` } });
+const readBody = await readRes.text();
+if (readRes.ok) {
+  const json = JSON.parse(readBody) as { value: Array<{ subject?: string }> };
+  console.log(
+    `✓ Mail.ReadWrite OK — ${json.value.length === 0 ? 'inbox empty' : `latest: "${json.value[0].subject}"`}`
+  );
+} else {
+  console.error(`❌ Mail.ReadWrite failed (${readRes.status}):`);
+  console.error(readBody);
+  console.error('\n→ Add the mailbox to your Application Access Policy:');
+  console.error(`  New-ApplicationAccessPolicy -AppId ${clientId} \`\n` +
+    `    -PolicyScopeGroupId ${mailbox} \`\n` +
+    `    -AccessRight RestrictAccess \`\n` +
+    `    -Description "ZapDesk — ${mailbox}"`);
+  process.exit(1);
+}
+
+// Send access — Graph getMailFolders is the cheapest probe that exercises the
+// same /users/{id}/ scope as sendMail without actually sending anything.
+const probeUrl = `https://graph.microsoft.com/v1.0/users/${encodeURIComponent(mailbox)}?$select=mail,userPrincipalName,displayName`;
+const probeRes = await fetch(probeUrl, { headers: { Authorization: `Bearer ${token}` } });
+if (probeRes.ok) {
+  const u = (await probeRes.json()) as {
+    mail?: string;
+    userPrincipalName?: string;
+    displayName?: string;
+  };
+  console.log(
+    `✓ Mailbox visible — ${u.displayName} <${u.mail || u.userPrincipalName}>`
+  );
+} else {
+  console.warn(`⚠ Could not resolve user record (${probeRes.status}) — sendMail may still work, but check the mailbox identity.`);
+}
+
+console.log(`\nReady. Update .env.local:`);
+console.log(`  MAIL_POLL_MAILBOX=${mailbox}`);
+console.log(`  MAIL_FROM=${mailbox}`);

--- a/scripts/check-mailbox-access.ts
+++ b/scripts/check-mailbox-access.ts
@@ -52,10 +52,12 @@ if (readRes.ok) {
   console.error(`❌ Mail.ReadWrite failed (${readRes.status}):`);
   console.error(readBody);
   console.error('\n→ Add the mailbox to your Application Access Policy:');
-  console.error(`  New-ApplicationAccessPolicy -AppId ${clientId} \`\n` +
-    `    -PolicyScopeGroupId ${mailbox} \`\n` +
-    `    -AccessRight RestrictAccess \`\n` +
-    `    -Description "ZapDesk — ${mailbox}"`);
+  console.error(
+    `  New-ApplicationAccessPolicy -AppId ${clientId} \`\n` +
+      `    -PolicyScopeGroupId ${mailbox} \`\n` +
+      `    -AccessRight RestrictAccess \`\n` +
+      `    -Description "ZapDesk — ${mailbox}"`
+  );
   process.exit(1);
 }
 
@@ -69,11 +71,11 @@ if (probeRes.ok) {
     userPrincipalName?: string;
     displayName?: string;
   };
-  console.log(
-    `✓ Mailbox visible — ${u.displayName} <${u.mail || u.userPrincipalName}>`
-  );
+  console.log(`✓ Mailbox visible — ${u.displayName} <${u.mail || u.userPrincipalName}>`);
 } else {
-  console.warn(`⚠ Could not resolve user record (${probeRes.status}) — sendMail may still work, but check the mailbox identity.`);
+  console.warn(
+    `⚠ Could not resolve user record (${probeRes.status}) — sendMail may still work, but check the mailbox identity.`
+  );
 }
 
 console.log(`\nReady. Update .env.local:`);

--- a/scripts/trigger-poll.ts
+++ b/scripts/trigger-poll.ts
@@ -1,0 +1,26 @@
+/**
+ * Manually trigger the inbound email poll against the local dev server.
+ * Reads EMAIL_WEBHOOK_SECRET from .env.local so the secret never lands in shell history.
+ *
+ * Usage: bun scripts/trigger-poll.ts
+ */
+
+const secret = process.env.EMAIL_WEBHOOK_SECRET;
+if (!secret) {
+  console.error('EMAIL_WEBHOOK_SECRET is not set in .env.local');
+  process.exit(1);
+}
+
+const url = process.argv[2] || 'http://localhost:3000/api/email/poll';
+
+const res = await fetch(url, {
+  method: 'POST',
+  headers: { 'x-webhook-secret': secret },
+});
+const text = await res.text();
+console.log(`HTTP ${res.status}`);
+try {
+  console.log(JSON.stringify(JSON.parse(text), null, 2));
+} catch {
+  console.log(text);
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,21 +2,95 @@
 
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { MainLayout } from '@/components/layout';
 import { LoadingSpinner, AzureDevOpsIcon } from '@/components/common';
-import { Settings, Code2, CheckCircle, XCircle } from 'lucide-react';
+import {
+  Settings,
+  Code2,
+  CheckCircle,
+  XCircle,
+  Mail,
+  Send,
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  Loader2,
+  Inbox,
+} from 'lucide-react';
 import { getSupportedTemplates, getTemplateConfig } from '@/config/process-templates';
+
+interface EmailConfig {
+  outbound: {
+    configured: boolean;
+    method: string;
+    from: string | null;
+    fromName: string | null;
+    azureAdConfigured: boolean;
+  };
+  inbound: {
+    webhookConfigured: boolean;
+    patConfigured: boolean;
+    pollMailbox: string | null;
+    pollConfigured: boolean;
+    ready: boolean;
+  };
+}
 
 export default function AdminPage() {
   const { data: session, status } = useSession();
   const router = useRouter();
+
+  const [emailConfig, setEmailConfig] = useState<EmailConfig | null>(null);
+  const [emailConfigLoading, setEmailConfigLoading] = useState(true);
+  const [testEmail, setTestEmail] = useState('');
+  const [testSending, setTestSending] = useState(false);
+  const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
+
+  const fetchEmailConfig = useCallback(async () => {
+    try {
+      const res = await fetch('/api/email/config');
+      if (res.ok) {
+        setEmailConfig(await res.json());
+      }
+    } catch {
+      // section will show as unconfigured
+    } finally {
+      setEmailConfigLoading(false);
+    }
+  }, []);
+
+  const handleSendTestEmail = async () => {
+    if (!testEmail || testSending) return;
+    setTestSending(true);
+    setTestResult(null);
+    try {
+      const res = await fetch('/api/email/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ to: testEmail }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setTestResult({ success: true, message: data.message });
+      } else {
+        setTestResult({ success: false, message: data.error || 'Failed to send test email' });
+      }
+    } catch {
+      setTestResult({ success: false, message: 'Network error' });
+    } finally {
+      setTestSending(false);
+    }
+  };
 
   useEffect(() => {
     if (status === 'unauthenticated') {
       router.push('/login');
     }
   }, [status, router]);
+
+  useEffect(() => {
+    if (session) fetchEmailConfig();
+  }, [session, fetchEmailConfig]);
 
   if (status === 'loading') {
     return (
@@ -237,6 +311,233 @@ export default function AdminPage() {
             >
               Request support for a new process template &rarr;
             </a>
+          </div>
+        </section>
+
+        {/* Email Channel Section */}
+        <section className="mb-8">
+          <div className="mb-4 flex items-center gap-2">
+            <Mail size={20} style={{ color: 'var(--text-muted)' }} />
+            <h2 className="text-lg font-semibold" style={{ color: 'var(--text-primary)' }}>
+              Email Channel
+            </h2>
+          </div>
+          <p className="mb-4 text-sm" style={{ color: 'var(--text-muted)' }}>
+            Customers raise tickets by emailing the support mailbox. Replies on existing tickets are
+            added as comments. The inbound poller checks for new mail every minute.
+          </p>
+
+          {emailConfigLoading ? (
+            <div className="flex items-center gap-2 py-8">
+              <LoadingSpinner size="sm" />
+              <span style={{ color: 'var(--text-muted)' }}>Loading email configuration...</span>
+            </div>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {/* Outbound Card */}
+              <div className="card p-4" style={{ borderColor: 'var(--border)' }}>
+                <div className="mb-3 flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <ArrowUpFromLine size={18} style={{ color: 'var(--text-muted)' }} />
+                    <h3 className="font-medium" style={{ color: 'var(--text-primary)' }}>
+                      Outbound (Graph API)
+                    </h3>
+                  </div>
+                  {emailConfig?.outbound.configured ? (
+                    <CheckCircle size={18} className="text-green-500" />
+                  ) : (
+                    <XCircle size={18} className="text-red-400" />
+                  )}
+                </div>
+
+                {emailConfig?.outbound.configured ? (
+                  <div className="space-y-2 text-sm">
+                    <div className="flex justify-between">
+                      <span style={{ color: 'var(--text-muted)' }}>Method</span>
+                      <span style={{ color: 'var(--text-secondary)' }}>Microsoft Graph API</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span style={{ color: 'var(--text-muted)' }}>From</span>
+                      <span style={{ color: 'var(--text-secondary)' }}>
+                        {emailConfig.outbound.fromName} &lt;{emailConfig.outbound.from}&gt;
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span style={{ color: 'var(--text-muted)' }}>Azure AD App</span>
+                      <CheckCircle size={14} className="text-green-500" />
+                    </div>
+                  </div>
+                ) : (
+                  <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
+                    Set <code className="text-xs">MAIL_FROM</code> (shared mailbox address) and
+                    ensure the Azure AD app has <code className="text-xs">Mail.Send</code>{' '}
+                    permission with admin consent.
+                  </p>
+                )}
+              </div>
+
+              {/* Inbound (Polling) Card */}
+              <div className="card p-4" style={{ borderColor: 'var(--border)' }}>
+                <div className="mb-3 flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <ArrowDownToLine size={18} style={{ color: 'var(--text-muted)' }} />
+                    <h3 className="font-medium" style={{ color: 'var(--text-primary)' }}>
+                      Inbound (Mailbox Poll)
+                    </h3>
+                  </div>
+                  {emailConfig?.inbound.pollConfigured ? (
+                    <CheckCircle size={18} className="text-green-500" />
+                  ) : (
+                    <XCircle size={18} className="text-red-400" />
+                  )}
+                </div>
+
+                <div className="space-y-2 text-sm">
+                  <div className="flex items-center justify-between">
+                    <span style={{ color: 'var(--text-muted)' }}>Mailbox</span>
+                    <span style={{ color: 'var(--text-secondary)' }}>
+                      {emailConfig?.inbound.pollMailbox || (
+                        <span style={{ color: 'var(--text-muted)' }}>not set</span>
+                      )}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span style={{ color: 'var(--text-muted)' }}>Webhook Secret</span>
+                    {emailConfig?.inbound.webhookConfigured ? (
+                      <CheckCircle size={14} className="text-green-500" />
+                    ) : (
+                      <XCircle size={14} className="text-red-400" />
+                    )}
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span style={{ color: 'var(--text-muted)' }}>Service Account (PAT)</span>
+                    {emailConfig?.inbound.patConfigured ? (
+                      <CheckCircle size={14} className="text-green-500" />
+                    ) : (
+                      <XCircle size={14} className="text-red-400" />
+                    )}
+                  </div>
+                  {emailConfig?.inbound.pollConfigured ? (
+                    <p className="mt-2 text-xs" style={{ color: 'var(--text-muted)' }}>
+                      Poll endpoint: <code className="text-xs">/api/email/poll</code> — drive from a
+                      1-minute cron.
+                    </p>
+                  ) : (
+                    <p className="mt-2 text-xs" style={{ color: 'var(--text-muted)' }}>
+                      Set <code className="text-xs">MAIL_POLL_MAILBOX</code>,{' '}
+                      <code className="text-xs">EMAIL_WEBHOOK_SECRET</code>, and{' '}
+                      <code className="text-xs">AZURE_DEVOPS_PAT</code> to enable inbound email.
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              {/* Send Test Email Card */}
+              <div className="card p-4" style={{ borderColor: 'var(--border)' }}>
+                <div className="mb-3 flex items-center gap-2">
+                  <Send size={18} style={{ color: 'var(--text-muted)' }} />
+                  <h3 className="font-medium" style={{ color: 'var(--text-primary)' }}>
+                    Send Test Email
+                  </h3>
+                </div>
+
+                {emailConfig?.outbound.configured ? (
+                  <div className="space-y-3">
+                    <input
+                      type="email"
+                      placeholder="recipient@example.com"
+                      value={testEmail}
+                      onChange={(e) => setTestEmail(e.target.value)}
+                      onKeyDown={(e) => e.key === 'Enter' && handleSendTestEmail()}
+                      className="w-full rounded-md border px-3 py-2 text-sm"
+                      style={{
+                        backgroundColor: 'var(--surface)',
+                        borderColor: 'var(--border)',
+                        color: 'var(--text-primary)',
+                      }}
+                    />
+                    <button
+                      onClick={handleSendTestEmail}
+                      disabled={!testEmail || testSending}
+                      className="flex w-full items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-white transition-opacity disabled:opacity-50"
+                      style={{ backgroundColor: 'var(--primary)' }}
+                    >
+                      {testSending ? (
+                        <>
+                          <Loader2 size={14} className="animate-spin" />
+                          Sending...
+                        </>
+                      ) : (
+                        <>
+                          <Send size={14} />
+                          Send Test
+                        </>
+                      )}
+                    </button>
+                    {testResult && (
+                      <div
+                        className="flex items-center gap-2 rounded-md px-3 py-2 text-xs"
+                        style={{
+                          backgroundColor: testResult.success
+                            ? 'rgba(34,197,94,0.1)'
+                            : 'rgba(239,68,68,0.1)',
+                          color: testResult.success ? '#22c55e' : '#ef4444',
+                        }}
+                      >
+                        {testResult.success ? <CheckCircle size={14} /> : <XCircle size={14} />}
+                        {testResult.message}
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
+                    Configure outbound email to send a test message.
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Email features summary */}
+          <div className="mt-4 rounded-lg p-4" style={{ backgroundColor: 'var(--surface-hover)' }}>
+            <p
+              className="mb-2 text-xs font-medium uppercase"
+              style={{ color: 'var(--text-muted)' }}
+            >
+              Email Features
+            </p>
+            <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm md:grid-cols-3">
+              {[
+                { label: 'Email-to-ticket', ready: emailConfig?.inbound.pollConfigured },
+                { label: 'Thread detection', ready: emailConfig?.inbound.pollConfigured },
+                {
+                  label: 'Mailbox polling (1 min)',
+                  ready: emailConfig?.inbound.pollConfigured,
+                  icon: Inbox,
+                },
+                {
+                  label: 'Confirmation emails',
+                  ready: emailConfig?.outbound.configured,
+                },
+                {
+                  label: 'Agent reply notifications',
+                  ready: emailConfig?.outbound.configured,
+                },
+                {
+                  label: 'Status change notifications',
+                  ready: emailConfig?.outbound.configured,
+                },
+              ].map((feature) => (
+                <div key={feature.label} className="flex items-center gap-1.5">
+                  {feature.ready ? (
+                    <CheckCircle size={12} className="shrink-0 text-green-500" />
+                  ) : (
+                    <XCircle size={12} className="shrink-0 text-red-400" />
+                  )}
+                  <span style={{ color: 'var(--text-secondary)' }}>{feature.label}</span>
+                </div>
+              ))}
+            </div>
           </div>
         </section>
       </div>

--- a/src/app/api/devops/tickets/[id]/comments/route.ts
+++ b/src/app/api/devops/tickets/[id]/comments/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { AzureDevOpsService } from '@/lib/devops';
+import { isEmailTicket, extractRequesterEmail, sendAgentReply } from '@/lib/email';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -82,6 +83,22 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           const commentText = isInternal ? `[Internal Note] ${comment}` : comment;
 
           await devopsService.addComment(project.name, ticketId, commentText);
+
+          // Email the requester for non-internal replies on email-created tickets.
+          // Fire-and-forget — never block the response on outbound mail.
+          if (!isInternal) {
+            const tags = workItem.fields?.['System.Tags'] || '';
+            if (isEmailTicket(tags)) {
+              const requesterEmail = extractRequesterEmail(tags);
+              if (requesterEmail) {
+                const subject = workItem.fields?.['System.Title'] || 'Your ticket';
+                const agentName = session.user?.name || 'Support Agent';
+                sendAgentReply(ticketId, subject, requesterEmail, agentName, comment).catch(
+                  () => {}
+                );
+              }
+            }
+          }
 
           return NextResponse.json({ success: true });
         }

--- a/src/app/api/devops/tickets/[id]/comments/route.ts
+++ b/src/app/api/devops/tickets/[id]/comments/route.ts
@@ -82,21 +82,67 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           // Add internal note prefix if needed
           const commentText = isInternal ? `[Internal Note] ${comment}` : comment;
 
+          // For email-tagged tickets, snapshot the prior conversation BEFORE
+          // adding the new comment so the agent's reply email shows everything
+          // up to (but not including) the message we're about to send.
+          // Order: newest comment first, original ticket description at the
+          // bottom — matches how email clients display threaded replies.
+          let priorHistory: Array<{
+            authorName: string;
+            createdAt: Date;
+            contentHtml: string;
+          }> = [];
+          const tags = workItem.fields?.['System.Tags'] || '';
+          const isEmail = !isInternal && isEmailTicket(tags);
+          if (isEmail) {
+            try {
+              const existing = await devopsService.getWorkItemComments(project.name, ticketId);
+              priorHistory = existing
+                .filter((c) => !c.content.includes('[Internal Note]'))
+                .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+                .map((c) => ({
+                  authorName: c.author.displayName || 'Unknown',
+                  createdAt: c.createdAt,
+                  contentHtml: c.content,
+                }));
+
+              // Append the original ticket description (the customer's first
+              // email) as the final entry. Use the requester from the
+              // email-from tag as author and the ticket's CreatedDate so the
+              // entry is rendered consistently with the rest.
+              const description = String(workItem.fields?.['System.Description'] || '');
+              const createdDateRaw = workItem.fields?.['System.CreatedDate'];
+              if (description) {
+                const requesterFromTag = extractRequesterEmail(tags);
+                priorHistory.push({
+                  authorName: requesterFromTag || 'Customer',
+                  createdAt: createdDateRaw ? new Date(String(createdDateRaw)) : new Date(0),
+                  contentHtml: description,
+                });
+              }
+            } catch (err) {
+              // History fetch is best-effort — don't block the comment on it.
+              console.warn(`Failed to fetch comment history for ticket #${ticketId}:`, err);
+            }
+          }
+
           await devopsService.addComment(project.name, ticketId, commentText);
 
-          // Email the requester for non-internal replies on email-created tickets.
-          // Fire-and-forget — never block the response on outbound mail.
-          if (!isInternal) {
-            const tags = workItem.fields?.['System.Tags'] || '';
-            if (isEmailTicket(tags)) {
-              const requesterEmail = extractRequesterEmail(tags);
-              if (requesterEmail) {
-                const subject = workItem.fields?.['System.Title'] || 'Your ticket';
-                const agentName = session.user?.name || 'Support Agent';
-                sendAgentReply(ticketId, subject, requesterEmail, agentName, comment).catch(
-                  () => {}
-                );
-              }
+          if (isEmail) {
+            const requesterEmail = extractRequesterEmail(tags);
+            if (requesterEmail) {
+              const subject = workItem.fields?.['System.Title'] || 'Your ticket';
+              const agentName = session.user?.name || 'Support Agent';
+              // Fire-and-forget — never block the response on outbound mail.
+              sendAgentReply(
+                ticketId,
+                subject,
+                requesterEmail,
+                agentName,
+                comment,
+                undefined,
+                priorHistory
+              ).catch(() => {});
             }
           }
 

--- a/src/app/api/devops/tickets/[id]/state/route.ts
+++ b/src/app/api/devops/tickets/[id]/state/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { AzureDevOpsService, workItemToTicket } from '@/lib/devops';
+import { isEmailTicket, extractRequesterEmail, sendStatusChangeNotification } from '@/lib/email';
 
 export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -30,7 +31,17 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
 
     // If project is provided in the body, use it directly
     if (body.project) {
+      // Snapshot old state first so the email shows the transition.
+      let oldState: string | undefined;
+      try {
+        const existing = await devopsService.getWorkItem(body.project, ticketId);
+        oldState = existing?.fields?.['System.State'];
+      } catch {
+        // Continue without old state — the transition message will say "Unknown".
+      }
+
       const updatedWorkItem = await devopsService.updateTicketState(body.project, ticketId, state);
+      notifyStateChange(updatedWorkItem, ticketId, oldState || 'Unknown', state);
       const ticket = workItemToTicket(updatedWorkItem);
       return NextResponse.json({ ticket });
     }
@@ -42,11 +53,15 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       try {
         const workItem = await devopsService.getWorkItem(project.name, ticketId);
         if (workItem) {
+          const oldState = workItem.fields?.['System.State'] || 'Unknown';
+
           const updatedWorkItem = await devopsService.updateTicketState(
             project.name,
             ticketId,
             state
           );
+
+          notifyStateChange(updatedWorkItem, ticketId, oldState, state);
 
           const ticket = workItemToTicket(updatedWorkItem, {
             id: project.id,
@@ -71,4 +86,23 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     console.error('Error updating ticket state:', error);
     return NextResponse.json({ error: 'Failed to update ticket state' }, { status: 500 });
   }
+}
+
+/** Fire-and-forget email notification for state changes on email-created tickets. */
+function notifyStateChange(
+  workItem: { fields?: Record<string, unknown> },
+  ticketId: number,
+  oldState: string,
+  newState: string
+) {
+  const tags = String(workItem.fields?.['System.Tags'] || '');
+  if (!isEmailTicket(tags)) return;
+
+  const requesterEmail = extractRequesterEmail(tags);
+  if (!requesterEmail) return;
+
+  const subject = String(workItem.fields?.['System.Title'] || 'Your ticket');
+  sendStatusChangeNotification(ticketId, subject, requesterEmail, oldState, newState).catch(
+    () => {}
+  );
 }

--- a/src/app/api/email/config/route.ts
+++ b/src/app/api/email/config/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { isEmailConfigured } from '@/lib/email';
+import { pollMailboxFromEnv } from '@/lib/email-poll';
+
+export async function GET() {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.accessToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const configured = isEmailConfigured();
+    const from = process.env.MAIL_FROM || '';
+    const fromName = process.env.MAIL_FROM_NAME || 'ZapDesk Support';
+    const webhookConfigured = Boolean(process.env.EMAIL_WEBHOOK_SECRET);
+    const patConfigured = Boolean(process.env.AZURE_DEVOPS_PAT);
+    const mailApp = Boolean(
+      (process.env.MAIL_CLIENT_ID || process.env.AZURE_AD_CLIENT_ID) &&
+      (process.env.MAIL_CLIENT_SECRET || process.env.AZURE_AD_CLIENT_SECRET)
+    );
+    const pollMailbox = pollMailboxFromEnv();
+
+    return NextResponse.json({
+      outbound: {
+        configured,
+        method: 'graph',
+        from: configured ? from.replace(/^[^@]+/, '***') : null,
+        fromName: configured ? fromName : null,
+        azureAdConfigured: mailApp,
+      },
+      inbound: {
+        webhookConfigured,
+        patConfigured,
+        pollMailbox: pollMailbox ? pollMailbox.replace(/^[^@]+/, '***') : null,
+        pollConfigured: Boolean(pollMailbox && webhookConfigured && patConfigured && mailApp),
+        ready: webhookConfigured && patConfigured,
+      },
+    });
+  } catch (error) {
+    console.error('Error fetching email config:', error);
+    return NextResponse.json({ error: 'Failed to fetch email config' }, { status: 500 });
+  }
+}

--- a/src/app/api/email/config/route.ts
+++ b/src/app/api/email/config/route.ts
@@ -20,8 +20,8 @@ export async function GET() {
     // so the admin UI can't claim "configured" while Graph calls still 401.
     const mailApp = Boolean(
       (process.env.MAIL_CLIENT_ID || process.env.AZURE_AD_CLIENT_ID) &&
-        (process.env.MAIL_CLIENT_SECRET || process.env.AZURE_AD_CLIENT_SECRET) &&
-        (process.env.MAIL_TENANT_ID || process.env.AZURE_AD_TENANT_ID)
+      (process.env.MAIL_CLIENT_SECRET || process.env.AZURE_AD_CLIENT_SECRET) &&
+      (process.env.MAIL_TENANT_ID || process.env.AZURE_AD_TENANT_ID)
     );
     const pollMailbox = pollMailboxFromEnv();
     const outboundReady = isEmailConfigured();

--- a/src/app/api/email/config/route.ts
+++ b/src/app/api/email/config/route.ts
@@ -16,11 +16,15 @@ export async function GET() {
     const fromName = process.env.MAIL_FROM_NAME || 'ZapDesk Support';
     const webhookConfigured = Boolean(process.env.EMAIL_WEBHOOK_SECRET);
     const patConfigured = Boolean(process.env.AZURE_DEVOPS_PAT);
+    // Mirror what isEmailConfigured() / getMailGraphToken() actually require
+    // so the admin UI can't claim "configured" while Graph calls still 401.
     const mailApp = Boolean(
       (process.env.MAIL_CLIENT_ID || process.env.AZURE_AD_CLIENT_ID) &&
-      (process.env.MAIL_CLIENT_SECRET || process.env.AZURE_AD_CLIENT_SECRET)
+        (process.env.MAIL_CLIENT_SECRET || process.env.AZURE_AD_CLIENT_SECRET) &&
+        (process.env.MAIL_TENANT_ID || process.env.AZURE_AD_TENANT_ID)
     );
     const pollMailbox = pollMailboxFromEnv();
+    const outboundReady = isEmailConfigured();
 
     return NextResponse.json({
       outbound: {
@@ -34,7 +38,7 @@ export async function GET() {
         webhookConfigured,
         patConfigured,
         pollMailbox: pollMailbox ? pollMailbox.replace(/^[^@]+/, '***') : null,
-        pollConfigured: Boolean(pollMailbox && webhookConfigured && patConfigured && mailApp),
+        pollConfigured: Boolean(pollMailbox && webhookConfigured && patConfigured && outboundReady),
         ready: webhookConfigured && patConfigured,
       },
     });

--- a/src/app/api/email/poll/route.ts
+++ b/src/app/api/email/poll/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { pollMailbox, pollMailboxFromEnv } from '@/lib/email-poll';
+
+// Cron-callable inbound email poller. Fetches unread mail in the configured
+// mailbox, creates / updates tickets, sends confirmations.
+//
+// Auth: shared `EMAIL_WEBHOOK_SECRET` header so an external scheduler can call
+// without a user session. The same secret already protects the push webhook.
+
+export async function POST(request: NextRequest) {
+  const secret = request.headers.get('x-webhook-secret');
+  if (secret !== process.env.EMAIL_WEBHOOK_SECRET) {
+    return NextResponse.json({ error: 'Invalid webhook secret' }, { status: 401 });
+  }
+
+  const mailbox = pollMailboxFromEnv();
+  if (!mailbox) {
+    return NextResponse.json({ error: 'MAIL_POLL_MAILBOX not configured' }, { status: 500 });
+  }
+
+  try {
+    const summary = await pollMailbox(mailbox);
+    return NextResponse.json(summary);
+  } catch (err) {
+    console.error(`[Poll] failed for ${mailbox}:`, err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Poll failed' },
+      { status: 500 }
+    );
+  }
+}
+
+// GET — lightweight health/status, useful for the admin UI to confirm config
+// without actually triggering a poll.
+export async function GET() {
+  const mailbox = pollMailboxFromEnv();
+  return NextResponse.json({
+    configured: Boolean(mailbox && process.env.EMAIL_WEBHOOK_SECRET),
+    mailbox: mailbox ? maskEmail(mailbox) : null,
+  });
+}
+
+function maskEmail(email: string): string {
+  const [local, domain] = email.split('@');
+  if (!domain) return email;
+  return `${local}@${domain}`;
+}

--- a/src/app/api/email/poll/route.ts
+++ b/src/app/api/email/poll/route.ts
@@ -42,6 +42,10 @@ export async function GET() {
 
 function maskEmail(email: string): string {
   const [local, domain] = email.split('@');
-  if (!domain) return email;
-  return `${local}@${domain}`;
+  if (!domain) return '***';
+  if (!local) return `***@${domain}`;
+  // Keep the first character so operators can still tell mailboxes apart in
+  // the admin UI without exposing the full local-part publicly.
+  const visible = local.slice(0, 1);
+  return `${visible}***@${domain}`;
 }

--- a/src/app/api/email/test/route.ts
+++ b/src/app/api/email/test/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { isEmailConfigured, sendTestEmail } from '@/lib/email';
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.accessToken) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (!isEmailConfigured()) {
+    return NextResponse.json({ error: 'Email service is not configured' }, { status: 400 });
+  }
+
+  let body: { to?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+  const to = body.to?.trim();
+  if (!to || !to.includes('@')) {
+    return NextResponse.json({ error: 'Recipient email is required' }, { status: 400 });
+  }
+
+  try {
+    await sendTestEmail(to);
+    return NextResponse.json({ success: true, message: `Test email sent to ${to}` });
+  } catch (err) {
+    console.error('Failed to send test email:', err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Failed to send test email' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/email/test/route.ts
+++ b/src/app/api/email/test/route.ts
@@ -24,6 +24,21 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Recipient email is required' }, { status: 400 });
   }
 
+  // Lock the test sender down to domains we own. Without this, any
+  // authenticated user could blast arbitrary inboxes from the shared support
+  // mailbox. Defaults to the MAIL_FROM domain; override with a comma-separated
+  // EMAIL_TEST_ALLOWED_DOMAINS for staging / multi-domain setups.
+  const recipientDomain = to.split('@')[1]?.toLowerCase();
+  const allowed = allowedTestDomains();
+  if (!recipientDomain || (allowed.length > 0 && !allowed.includes(recipientDomain))) {
+    return NextResponse.json(
+      {
+        error: `Test emails are restricted to: ${allowed.join(', ') || '(no domains configured)'}`,
+      },
+      { status: 403 }
+    );
+  }
+
   try {
     await sendTestEmail(to);
     return NextResponse.json({ success: true, message: `Test email sent to ${to}` });
@@ -34,4 +49,16 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+function allowedTestDomains(): string[] {
+  const explicit = process.env.EMAIL_TEST_ALLOWED_DOMAINS;
+  if (explicit) {
+    return explicit
+      .split(',')
+      .map((d) => d.trim().toLowerCase())
+      .filter(Boolean);
+  }
+  const fromDomain = (process.env.MAIL_FROM || '').split('@')[1]?.toLowerCase();
+  return fromDomain ? [fromDomain] : [];
 }

--- a/src/app/api/email/webhook/route.ts
+++ b/src/app/api/email/webhook/route.ts
@@ -1,179 +1,33 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getProjectFromEmail } from '@/lib/devops';
+import { ingestEmail } from '@/lib/email-ingest';
 import type { EmailWebhookPayload } from '@/types';
 
-// This endpoint receives emails from email providers like SendGrid, Mailgun, etc.
-// Emails sent to zapdesk@knowall.ai will be forwarded here to create tickets
+// Push-style webhook for inbound email. The primary inbound path is the
+// 1-minute Graph poller (`/api/email/poll`); this webhook stays as a secondary
+// option for forwarders that prefer to push (Power Automate, Logic Apps,
+// SendGrid Inbound, etc.).
 
 export async function POST(request: NextRequest) {
   try {
-    // Verify webhook secret
     const webhookSecret = request.headers.get('x-webhook-secret');
     if (webhookSecret !== process.env.EMAIL_WEBHOOK_SECRET) {
       return NextResponse.json({ error: 'Invalid webhook secret' }, { status: 401 });
     }
 
     const payload: EmailWebhookPayload = await request.json();
-    const { from, subject, body } = payload;
-
-    // Validate required fields
-    if (!from || !subject) {
-      return NextResponse.json(
-        { error: 'Missing required fields: from, subject' },
-        { status: 400 }
-      );
-    }
-
-    // Extract sender email
-    const senderEmail = extractEmail(from);
-    if (!senderEmail) {
-      return NextResponse.json({ error: 'Invalid sender email' }, { status: 400 });
-    }
-
-    // Determine which project to create the ticket in based on sender domain
-    // This queries DevOps project descriptions for email domain mappings
-    const projectName = await getProjectFromEmail(senderEmail);
-
-    if (!projectName) {
-      // Default to a general project or return error
-      console.warn(`No project mapping for email domain: ${senderEmail}`);
-      return NextResponse.json(
-        { error: 'No project mapping found for sender domain' },
-        { status: 400 }
-      );
-    }
-
-    // Use service account PAT for creating tickets
-    const pat = process.env.AZURE_DEVOPS_PAT;
-    if (!pat) {
-      console.error('AZURE_DEVOPS_PAT not configured');
-      return NextResponse.json({ error: 'Service not configured' }, { status: 500 });
-    }
-
-    // Create Azure DevOps service with PAT (base64 encoded)
-    const encodedPat = Buffer.from(`:${pat}`).toString('base64');
-    const devopsService = new AzureDevOpsServiceWithPAT(encodedPat);
-
-    // Determine priority from subject line keywords
-    const priority = determinePriority(subject);
-
-    // Create the ticket
-    const workItem = await devopsService.createTicket(
-      projectName,
-      subject,
-      formatEmailBody(body, senderEmail),
-      senderEmail,
-      priority
-    );
-
-    console.log(`Created ticket #${workItem.id} from email: ${senderEmail}`);
-
-    return NextResponse.json({
-      success: true,
-      ticketId: workItem.id,
-      project: projectName,
+    const result = await ingestEmail({
+      from: payload.from,
+      subject: payload.subject,
+      body: payload.body,
+      attachments: payload.attachments,
     });
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: result.status });
+    }
+    return NextResponse.json(result);
   } catch (error) {
     console.error('Error processing email webhook:', error);
     return NextResponse.json({ error: 'Failed to process email' }, { status: 500 });
   }
-}
-
-// Helper class for PAT authentication
-class AzureDevOpsServiceWithPAT {
-  private encodedPat: string;
-  private organization: string;
-
-  constructor(encodedPat: string, organization: string = 'KnowAll') {
-    this.encodedPat = encodedPat;
-    this.organization = organization;
-  }
-
-  private get baseUrl(): string {
-    return `https://dev.azure.com/${this.organization}`;
-  }
-
-  private get headers(): HeadersInit {
-    return {
-      Authorization: `Basic ${this.encodedPat}`,
-      'Content-Type': 'application/json',
-    };
-  }
-
-  async createTicket(
-    projectName: string,
-    title: string,
-    description: string,
-    requesterEmail: string,
-    priority: number = 3
-  ) {
-    const patchDocument = [
-      { op: 'add', path: '/fields/System.Title', value: title },
-      { op: 'add', path: '/fields/System.Description', value: description },
-      { op: 'add', path: '/fields/System.Tags', value: 'ticket; email' },
-      { op: 'add', path: '/fields/Microsoft.VSTS.Common.Priority', value: priority },
-      {
-        op: 'add',
-        path: '/fields/System.History',
-        value: `Ticket created from email by ${requesterEmail}`,
-      },
-    ];
-
-    const response = await fetch(
-      `${this.baseUrl}/${encodeURIComponent(projectName)}/_apis/wit/workitems/$Task?api-version=7.0`,
-      {
-        method: 'POST',
-        headers: {
-          ...this.headers,
-          'Content-Type': 'application/json-patch+json',
-        },
-        body: JSON.stringify(patchDocument),
-      }
-    );
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`Failed to create work item: ${response.statusText} - ${errorText}`);
-    }
-
-    return response.json();
-  }
-}
-
-function extractEmail(from: string): string | null {
-  // Handle formats like "Name <email@domain.com>" or just "email@domain.com"
-  const emailMatch = from.match(/<([^>]+)>/) || from.match(/([^\s]+@[^\s]+)/);
-  return emailMatch ? emailMatch[1].toLowerCase() : null;
-}
-
-function determinePriority(subject: string): number {
-  const lowerSubject = subject.toLowerCase();
-
-  if (
-    lowerSubject.includes('urgent') ||
-    lowerSubject.includes('critical') ||
-    lowerSubject.includes('emergency')
-  ) {
-    return 1; // Urgent
-  }
-
-  if (lowerSubject.includes('high priority') || lowerSubject.includes('important')) {
-    return 2; // High
-  }
-
-  if (lowerSubject.includes('low priority') || lowerSubject.includes('when you can')) {
-    return 4; // Low
-  }
-
-  return 3; // Normal
-}
-
-function formatEmailBody(body: string, senderEmail: string): string {
-  return `
-<div style="font-family: sans-serif;">
-  <p><strong>From:</strong> ${senderEmail}</p>
-  <hr/>
-  <div>${body || '<em>No content</em>'}</div>
-</div>
-  `.trim();
 }

--- a/src/lib/email-clean.ts
+++ b/src/lib/email-clean.ts
@@ -1,0 +1,82 @@
+/**
+ * Email body sanitisation for inbound mail.
+ *
+ * Inputs: plain-text `uniqueBody` from Microsoft Graph (already strips the
+ * quoted thread from previous messages in the conversation).
+ * Outputs: trimmed text with signatures and confidentiality notices removed,
+ * then HTML-escaped and wrapped for safe DevOps storage.
+ */
+
+const MAX_BODY_CHARS = 50_000;
+
+/** Strip common signature blocks from the tail of a plain-text email body. */
+export function stripSignature(body: string): string {
+  if (!body) return '';
+
+  const lines = body.replace(/\r\n/g, '\n').split('\n');
+  const cutPoints: number[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    // RFC 3676: signature delimiter is "-- " on its own line. Some clients
+    // ship "--" without trailing space — accept both.
+    if (trimmed === '--' || trimmed === '-- ') {
+      cutPoints.push(i);
+      continue;
+    }
+
+    // Common mobile auto-signatures
+    if (
+      /^Sent from my (iPhone|iPad|Android|Galaxy|BlackBerry)/i.test(trimmed) ||
+      /^Sent from (Outlook|Mail) for (iOS|Android|Windows)/i.test(trimmed) ||
+      /^Get Outlook for (iOS|Android)/i.test(trimmed)
+    ) {
+      cutPoints.push(i);
+      continue;
+    }
+
+    // Confidentiality / disclaimer notices — usually all-caps headings or
+    // long boilerplate paragraphs at the end of corporate mail.
+    if (
+      /^(CONFIDENTIAL(ITY)?( NOTICE)?|DISCLAIMER|PRIVILEGED AND CONFIDENTIAL|NOTICE:)\s*[:.\-]?\s*$/i.test(
+        trimmed
+      ) ||
+      /^This (e-?mail|message) (and any|is intended|may contain)/i.test(trimmed) ||
+      /is a limited company incorporated in/i.test(trimmed)
+    ) {
+      cutPoints.push(i);
+      continue;
+    }
+  }
+
+  if (cutPoints.length === 0) return body.trim();
+
+  // Keep only what's above the earliest cut point.
+  const cleaned = lines.slice(0, cutPoints[0]).join('\n').trimEnd();
+  return cleaned;
+}
+
+/** HTML-escape user input before embedding in DevOps fields. */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/** Clean + escape + wrap a plain-text email body for safe HTML storage. */
+export function renderEmailBody(rawText: string): string {
+  const stripped = stripSignature(rawText);
+  const truncated =
+    stripped.length > MAX_BODY_CHARS
+      ? stripped.slice(0, MAX_BODY_CHARS) + '\n\n[truncated]'
+      : stripped;
+  if (!truncated.trim()) return '<em>No content</em>';
+  return `<pre style="white-space: pre-wrap; font-family: inherit; margin: 0;">${escapeHtml(
+    truncated
+  )}</pre>`;
+}

--- a/src/lib/email-clean.ts
+++ b/src/lib/email-clean.ts
@@ -14,26 +14,37 @@ export function stripSignature(body: string): string {
   if (!body) return '';
 
   const lines = body.replace(/\r\n/g, '\n').split('\n');
-  const cutPoints: number[] = [];
+
+  // Two categories so we don't drop legitimate content that happens to look
+  // like a disclaimer when it appears mid-body.
+  //   - "Hard" delimiters always mark end-of-message (RFC 3676 `-- `, mobile
+  //     auto-signatures). Take the FIRST occurrence — everything below it is
+  //     signature by contract.
+  //   - "Soft" matches (DISCLAIMER, "This e-mail is intended", incorporation
+  //     boilerplate) can appear in legit content (e.g., a customer asking
+  //     about a disclaimer they received). Scan from the bottom and only
+  //     cut at the LAST one, so the boilerplate at the very end is removed
+  //     but a passing reference in the body is preserved.
+  const hardCutPoints: number[] = [];
+  const softCutPoints: number[] = [];
 
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    const trimmed = line.trim();
+    const trimmed = lines[i].trim();
 
     // RFC 3676: signature delimiter is "-- " on its own line. Some clients
     // ship "--" without trailing space — accept both.
     if (trimmed === '--' || trimmed === '-- ') {
-      cutPoints.push(i);
+      hardCutPoints.push(i);
       continue;
     }
 
-    // Common mobile auto-signatures
+    // Common mobile auto-signatures — also reliably at end of message.
     if (
       /^Sent from my (iPhone|iPad|Android|Galaxy|BlackBerry)/i.test(trimmed) ||
       /^Sent from (Outlook|Mail) for (iOS|Android|Windows)/i.test(trimmed) ||
       /^Get Outlook for (iOS|Android)/i.test(trimmed)
     ) {
-      cutPoints.push(i);
+      hardCutPoints.push(i);
       continue;
     }
 
@@ -46,16 +57,20 @@ export function stripSignature(body: string): string {
       /^This (e-?mail|message) (and any|is intended|may contain)/i.test(trimmed) ||
       /is a limited company incorporated in/i.test(trimmed)
     ) {
-      cutPoints.push(i);
+      softCutPoints.push(i);
       continue;
     }
   }
 
-  if (cutPoints.length === 0) return body.trim();
+  let cutAt: number | null = null;
+  if (hardCutPoints.length > 0) {
+    cutAt = hardCutPoints[0];
+  } else if (softCutPoints.length > 0) {
+    cutAt = softCutPoints[softCutPoints.length - 1];
+  }
+  if (cutAt === null) return body.trim();
 
-  // Keep only what's above the earliest cut point.
-  const cleaned = lines.slice(0, cutPoints[0]).join('\n').trimEnd();
-  return cleaned;
+  return lines.slice(0, cutAt).join('\n').trimEnd();
 }
 
 /** HTML-escape user input before embedding in DevOps fields. */

--- a/src/lib/email-ingest.ts
+++ b/src/lib/email-ingest.ts
@@ -1,0 +1,265 @@
+/**
+ * Shared inbound-email-to-ticket logic.
+ *
+ * Both the polling job (`/api/email/poll` -> Graph mailbox poll) and the
+ * push-style webhook (`/api/email/webhook`) end up calling `ingestEmail` so the
+ * ticket-creation, threading, and confirmation behaviour stays identical no
+ * matter how the message arrived.
+ */
+
+import { getProjectFromEmail } from '@/lib/devops';
+import { sendTicketConfirmation } from '@/lib/email';
+import { escapeHtml, renderEmailBody } from '@/lib/email-clean';
+
+const TICKET_REF_REGEX = /\[ZapDesk #(\d+)\]/;
+
+export interface IngestableEmail {
+  /** Raw `From` value — `Name <user@domain>` or bare `user@domain`. */
+  from: string;
+  subject: string;
+  /** HTML or text body. Used as-is inside the ticket description / comment. */
+  body: string;
+  attachments?: Array<{ filename: string; contentType: string; content: string }>;
+}
+
+export type IngestResult =
+  | { success: true; action: 'ticket_created'; ticketId: number; project: string }
+  | { success: true; action: 'comment_added'; ticketId: number }
+  | { success: false; status: number; error: string };
+
+export async function ingestEmail(email: IngestableEmail): Promise<IngestResult> {
+  if (!email.from || !email.subject) {
+    return { success: false, status: 400, error: 'Missing required fields: from, subject' };
+  }
+
+  const senderEmail = extractEmail(email.from);
+  if (!senderEmail) {
+    return { success: false, status: 400, error: 'Invalid sender email' };
+  }
+
+  const pat = process.env.AZURE_DEVOPS_PAT;
+  if (!pat) {
+    console.error('AZURE_DEVOPS_PAT not configured');
+    return { success: false, status: 500, error: 'Service not configured' };
+  }
+  const encodedPat = Buffer.from(`:${pat}`).toString('base64');
+
+  const ticketMatch = email.subject.match(TICKET_REF_REGEX);
+  if (ticketMatch) {
+    const ticketId = parseInt(ticketMatch[1], 10);
+    return handleThreadReply(encodedPat, ticketId, senderEmail, email.body);
+  }
+  return handleNewTicket(encodedPat, senderEmail, email);
+}
+
+async function handleNewTicket(
+  encodedPat: string,
+  senderEmail: string,
+  email: IngestableEmail
+): Promise<IngestResult> {
+  const projectName = await getProjectFromEmail(senderEmail);
+  if (!projectName) {
+    console.warn(`No project mapping for email domain: ${senderEmail}`);
+    return { success: false, status: 400, error: 'No project mapping found for sender domain' };
+  }
+
+  const devops = new AzureDevOpsServiceWithPAT(encodedPat);
+  const priority = determinePriority(email.subject);
+
+  const workItem = await devops.createTicket(
+    projectName,
+    email.subject,
+    formatEmailBody(email.body, senderEmail),
+    senderEmail,
+    priority
+  );
+  const ticketId = workItem.id;
+  console.log(`Created ticket #${ticketId} from email: ${senderEmail}`);
+
+  if (email.attachments?.length) {
+    for (const attachment of email.attachments) {
+      try {
+        await devops.uploadAttachment(projectName, ticketId, attachment);
+      } catch (err) {
+        console.error(`Failed to upload attachment ${attachment.filename}:`, err);
+      }
+    }
+  }
+
+  // Fire-and-forget — never block ticket creation on email send.
+  sendTicketConfirmation(ticketId, email.subject, senderEmail).catch(() => {});
+
+  return { success: true, action: 'ticket_created', ticketId, project: projectName };
+}
+
+async function handleThreadReply(
+  encodedPat: string,
+  ticketId: number,
+  senderEmail: string,
+  body: string
+): Promise<IngestResult> {
+  const devops = new AzureDevOpsServiceWithPAT(encodedPat);
+  try {
+    const commentHtml = `
+<div style="font-family: sans-serif;">
+  <p><strong>Email reply from:</strong> ${escapeHtml(senderEmail)}</p>
+  <hr/>
+  ${renderEmailBody(body)}
+</div>`.trim();
+
+    await devops.addComment(ticketId, commentHtml);
+    console.log(`Added email reply to ticket #${ticketId} from ${senderEmail}`);
+    return { success: true, action: 'comment_added', ticketId };
+  } catch (error) {
+    console.error(`Failed to add comment to ticket #${ticketId}:`, error);
+    return { success: false, status: 500, error: 'Failed to add comment to ticket' };
+  }
+}
+
+class AzureDevOpsServiceWithPAT {
+  private encodedPat: string;
+  private organization: string;
+
+  constructor(encodedPat: string, organization?: string) {
+    this.encodedPat = encodedPat;
+    this.organization = organization || process.env.AZURE_DEVOPS_ORG || 'KnowAll';
+  }
+
+  private get baseUrl(): string {
+    return `https://dev.azure.com/${this.organization}`;
+  }
+
+  private get headers(): Record<string, string> {
+    return {
+      Authorization: `Basic ${this.encodedPat}`,
+      'Content-Type': 'application/json',
+    };
+  }
+
+  async createTicket(
+    projectName: string,
+    title: string,
+    description: string,
+    requesterEmail: string,
+    priority: number = 3
+  ) {
+    const patchDocument = [
+      { op: 'add', path: '/fields/System.Title', value: title },
+      { op: 'add', path: '/fields/System.Description', value: description },
+      {
+        op: 'add',
+        path: '/fields/System.Tags',
+        value: `ticket; email; email-from:${requesterEmail}`,
+      },
+      { op: 'add', path: '/fields/Microsoft.VSTS.Common.Priority', value: priority },
+      {
+        op: 'add',
+        path: '/fields/System.History',
+        value: `Ticket created from email by ${requesterEmail}`,
+      },
+    ];
+
+    const response = await fetch(
+      `${this.baseUrl}/${encodeURIComponent(projectName)}/_apis/wit/workitems/$Task?api-version=7.0`,
+      {
+        method: 'POST',
+        headers: { ...this.headers, 'Content-Type': 'application/json-patch+json' },
+        body: JSON.stringify(patchDocument),
+      }
+    );
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to create work item: ${response.statusText} - ${errorText}`);
+    }
+    return response.json();
+  }
+
+  async addComment(ticketId: number, commentHtml: string) {
+    const patchDocument = [{ op: 'add', path: '/fields/System.History', value: commentHtml }];
+    const response = await fetch(
+      `${this.baseUrl}/_apis/wit/workitems/${ticketId}?api-version=7.0`,
+      {
+        method: 'PATCH',
+        headers: { ...this.headers, 'Content-Type': 'application/json-patch+json' },
+        body: JSON.stringify(patchDocument),
+      }
+    );
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to add comment: ${response.statusText} - ${errorText}`);
+    }
+    return response.json();
+  }
+
+  async uploadAttachment(
+    projectName: string,
+    workItemId: number,
+    attachment: { filename: string; contentType: string; content: string }
+  ) {
+    const buffer = Buffer.from(attachment.content, 'base64');
+    const uploadResponse = await fetch(
+      `${this.baseUrl}/${encodeURIComponent(projectName)}/_apis/wit/attachments?fileName=${encodeURIComponent(attachment.filename)}&api-version=7.0`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${this.encodedPat}`,
+          'Content-Type': 'application/octet-stream',
+        },
+        body: buffer,
+      }
+    );
+    if (!uploadResponse.ok) {
+      throw new Error(`Failed to upload attachment: ${uploadResponse.statusText}`);
+    }
+    const uploadData = await uploadResponse.json();
+    const attachmentUrl = uploadData.url;
+
+    const patchDocument = [
+      {
+        op: 'add',
+        path: '/relations/-',
+        value: {
+          rel: 'AttachedFile',
+          url: attachmentUrl,
+          attributes: { comment: `Email attachment: ${attachment.filename}` },
+        },
+      },
+    ];
+    const linkResponse = await fetch(
+      `${this.baseUrl}/_apis/wit/workitems/${workItemId}?api-version=7.0`,
+      {
+        method: 'PATCH',
+        headers: { ...this.headers, 'Content-Type': 'application/json-patch+json' },
+        body: JSON.stringify(patchDocument),
+      }
+    );
+    if (!linkResponse.ok) {
+      throw new Error(`Failed to link attachment: ${linkResponse.statusText}`);
+    }
+  }
+}
+
+function extractEmail(from: string): string | null {
+  const emailMatch = from.match(/<([^>]+)>/) || from.match(/([^\s]+@[^\s]+)/);
+  return emailMatch ? emailMatch[1].toLowerCase() : null;
+}
+
+function determinePriority(subject: string): number {
+  const lower = subject.toLowerCase();
+  if (lower.includes('urgent') || lower.includes('critical') || lower.includes('emergency')) {
+    return 1;
+  }
+  if (lower.includes('high priority') || lower.includes('important')) return 2;
+  if (lower.includes('low priority') || lower.includes('when you can')) return 4;
+  return 3;
+}
+
+function formatEmailBody(body: string, senderEmail: string): string {
+  return `
+<div style="font-family: sans-serif;">
+  <p><strong>From:</strong> ${escapeHtml(senderEmail)}</p>
+  <hr/>
+  ${renderEmailBody(body)}
+</div>
+  `.trim();
+}

--- a/src/lib/email-ingest.ts
+++ b/src/lib/email-ingest.ts
@@ -17,7 +17,11 @@ export interface IngestableEmail {
   /** Raw `From` value — `Name <user@domain>` or bare `user@domain`. */
   from: string;
   subject: string;
-  /** HTML or text body. Used as-is inside the ticket description / comment. */
+  /**
+   * Plain-text body of the message. Passed through `renderEmailBody`, which
+   * strips signatures, HTML-escapes the content, and wraps it in a `<pre>`
+   * block — raw HTML in this field is escaped, not preserved.
+   */
   body: string;
   attachments?: Array<{ filename: string; contentType: string; content: string }>;
 }

--- a/src/lib/email-poll.ts
+++ b/src/lib/email-poll.ts
@@ -1,0 +1,204 @@
+/**
+ * Microsoft Graph mailbox polling for inbound email.
+ *
+ * Replaces the more brittle change-notification subscription approach: every
+ * call lists unread Inbox messages, ingests each one, then marks it read so it
+ * isn't re-processed. Wire this up to a 1-minute cron (GitHub Actions, Azure
+ * WebJob, ...) and customers raising tickets by email get a confirmation
+ * within ~60 seconds of sending.
+ *
+ * Required Graph permissions on the mail Azure AD app:
+ *   - `Mail.ReadWrite` (Application) — read + flag-as-read
+ *   - `Mail.Send` (Application) — outbound from `email.ts`
+ * Both should be scoped via Application Access Policy to the support mailbox.
+ */
+
+import { getMailGraphToken } from './email';
+import { ingestEmail, type IngestResult } from './email-ingest';
+
+const GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
+
+// Cap per poll so a backlog can't time out the cron call. With a 1-minute
+// schedule even 25 / minute = 1500 / hour which is plenty for B2B support.
+const MAX_PER_POLL = 25;
+
+interface GraphMessage {
+  id: string;
+  subject?: string;
+  from?: { emailAddress?: { address?: string; name?: string } };
+  /** Only the new content of the message, with quoted thread stripped by Graph. */
+  uniqueBody?: { contentType: string; content: string };
+  hasAttachments?: boolean;
+  receivedDateTime?: string;
+}
+
+interface GraphFileAttachment {
+  '@odata.type': string;
+  id: string;
+  name: string;
+  contentType: string;
+  size: number;
+  isInline: boolean;
+  contentBytes: string;
+}
+
+export interface PollSummary {
+  mailbox: string;
+  fetched: number;
+  ingested: number;
+  failed: number;
+  results: Array<{
+    messageId: string;
+    subject?: string;
+    result: IngestResult;
+  }>;
+}
+
+export function pollMailboxFromEnv(): string | null {
+  return process.env.MAIL_POLL_MAILBOX || null;
+}
+
+export async function pollMailbox(mailbox: string): Promise<PollSummary> {
+  const token = await getMailGraphToken();
+  const messages = await listUnread(token, mailbox);
+
+  const summary: PollSummary = {
+    mailbox,
+    fetched: messages.length,
+    ingested: 0,
+    failed: 0,
+    results: [],
+  };
+
+  for (const message of messages) {
+    const fromAddress = message.from?.emailAddress?.address;
+    if (!fromAddress) {
+      console.warn(`[Poll] message ${message.id} has no from address — marking read`);
+      await markRead(token, mailbox, message.id);
+      summary.failed += 1;
+      summary.results.push({
+        messageId: message.id,
+        subject: message.subject,
+        result: { success: false, status: 400, error: 'No from address' },
+      });
+      continue;
+    }
+
+    const fromName = message.from?.emailAddress?.name;
+    const from = fromName ? `${fromName} <${fromAddress}>` : fromAddress;
+
+    let attachments: Array<{ filename: string; contentType: string; content: string }> | undefined;
+    if (message.hasAttachments) {
+      try {
+        attachments = await fetchAttachments(token, mailbox, message.id);
+      } catch (err) {
+        console.warn(`[Poll] failed to fetch attachments for ${message.id}:`, err);
+      }
+    }
+
+    const result = await ingestEmail({
+      from,
+      subject: message.subject || '(no subject)',
+      body: message.uniqueBody?.content || '',
+      attachments,
+    });
+
+    if (result.success) {
+      // Only mark read on success so retries pick the message up next poll.
+      await markRead(token, mailbox, message.id);
+      summary.ingested += 1;
+    } else {
+      summary.failed += 1;
+      console.error(
+        `[Poll] ingest failed for message ${message.id} (${message.subject}): ${result.error}`
+      );
+      // Leave the message unread — operator can investigate, next run retries.
+    }
+
+    summary.results.push({ messageId: message.id, subject: message.subject, result });
+  }
+
+  if (summary.fetched > 0) {
+    console.log(
+      `[Poll] ${mailbox}: fetched=${summary.fetched} ingested=${summary.ingested} failed=${summary.failed}`
+    );
+  }
+  return summary;
+}
+
+async function listUnread(token: string, mailbox: string): Promise<GraphMessage[]> {
+  // Newest-first: ensures freshly arrived mail is always within the page even
+  // when older unread messages can't be ingested (e.g. spam, system notifications,
+  // domains that don't map to a project) and stay unread forever.
+  const url =
+    `${GRAPH_BASE_URL}/users/${encodeURIComponent(mailbox)}/mailFolders('Inbox')/messages` +
+    `?$filter=isRead eq false` +
+    `&$select=id,subject,from,uniqueBody,hasAttachments,receivedDateTime` +
+    `&$orderby=receivedDateTime desc` +
+    `&$top=${MAX_PER_POLL}`;
+
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      // Plain text instead of HTML — drops inline CSS, embedded images, etc.
+      // Combined with $select=uniqueBody this gives us only the new content
+      // the customer wrote, in a form we can safely escape and re-wrap.
+      Prefer: 'outlook.body-content-type="text"',
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Graph list-messages failed (${res.status}): ${text}`);
+  }
+  const json = (await res.json()) as { value?: GraphMessage[] };
+  return json.value || [];
+}
+
+async function fetchAttachments(
+  token: string,
+  mailbox: string,
+  messageId: string
+): Promise<Array<{ filename: string; contentType: string; content: string }>> {
+  const url = `${GRAPH_BASE_URL}/users/${encodeURIComponent(mailbox)}/messages/${encodeURIComponent(messageId)}/attachments`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!res.ok) {
+    throw new Error(`Graph list-attachments failed (${res.status}): ${await res.text()}`);
+  }
+  const json = (await res.json()) as { value?: GraphFileAttachment[] };
+  const result: Array<{ filename: string; contentType: string; content: string }> = [];
+  for (const a of json.value || []) {
+    // Only fileAttachment with contentBytes — itemAttachment (forwarded message)
+    // and referenceAttachment (cloud links) need different handling and are rare
+    // in support traffic.
+    if (a['@odata.type'] !== '#microsoft.graph.fileAttachment') continue;
+    if (a.isInline) continue; // skip inline images embedded in the email body
+    if (!a.contentBytes) continue;
+    result.push({
+      filename: a.name || `attachment-${a.id}`,
+      contentType: a.contentType || 'application/octet-stream',
+      content: a.contentBytes,
+    });
+  }
+  return result;
+}
+
+async function markRead(token: string, mailbox: string, messageId: string): Promise<void> {
+  const res = await fetch(
+    `${GRAPH_BASE_URL}/users/${encodeURIComponent(mailbox)}/messages/${encodeURIComponent(messageId)}`,
+    {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ isRead: true }),
+    }
+  );
+  if (!res.ok) {
+    const text = await res.text();
+    // Don't throw — failing to flag-as-read just means we'll re-process the
+    // message next poll. Worst case is a duplicate ticket; better than
+    // dropping the entire poll.
+    console.warn(`[Poll] failed to mark ${messageId} read (${res.status}): ${text}`);
+  }
+}

--- a/src/lib/email-poll.ts
+++ b/src/lib/email-poll.ts
@@ -170,8 +170,14 @@ async function fetchAttachments(
     // Only fileAttachment with contentBytes — itemAttachment (forwarded message)
     // and referenceAttachment (cloud links) need different handling and are rare
     // in support traffic.
+    //
+    // Inline attachments (`isInline=true`) are also uploaded: Outlook and Gmail
+    // flag pasted screenshots and dragged-in images as inline even when users
+    // expect them as attachments, so dropping them silently loses common
+    // support artifacts. We extract the body as plain `uniqueBody`, so the
+    // inline reference in the HTML is gone — surfacing the file on the ticket
+    // is what matters.
     if (a['@odata.type'] !== '#microsoft.graph.fileAttachment') continue;
-    if (a.isInline) continue; // skip inline images embedded in the email body
     if (!a.contentBytes) continue;
     result.push({
       filename: a.name || `attachment-${a.id}`,

--- a/src/lib/email-templates.ts
+++ b/src/lib/email-templates.ts
@@ -1,0 +1,119 @@
+/**
+ * HTML email templates for ZapDesk outbound mail.
+ * All templates share a common card layout with branding.
+ */
+
+const APP_NAME = process.env.APP_NAME || 'ZapDesk';
+const APP_URL = process.env.APP_URL || process.env.NEXTAUTH_URL || 'http://localhost:3000';
+
+function layoutWrapper(content: string): string {
+  return `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <style>
+    body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background-color: #f4f4f5; color: #18181b; }
+    .container { max-width: 600px; margin: 0 auto; padding: 24px; }
+    .card { background: #ffffff; border-radius: 8px; padding: 24px; border: 1px solid #e4e4e7; }
+    .header { text-align: center; margin-bottom: 24px; }
+    .header h1 { font-size: 20px; color: #22c55e; margin: 0; }
+    .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 12px; font-weight: 600; }
+    .badge-new { background: #3b82f6; color: #fff; }
+    .badge-active { background: #22c55e; color: #fff; }
+    .badge-resolved { background: #8b5cf6; color: #fff; }
+    .badge-closed { background: #6b7280; color: #fff; }
+    .content { margin: 16px 0; line-height: 1.6; }
+    .quoted { border-left: 3px solid #d4d4d8; padding-left: 12px; margin: 16px 0; color: #71717a; }
+    .footer { text-align: center; margin-top: 24px; font-size: 12px; color: #a1a1aa; }
+    .footer a { color: #22c55e; text-decoration: none; }
+    .btn { display: inline-block; padding: 10px 20px; background: #22c55e; color: #fff; text-decoration: none; border-radius: 6px; font-weight: 600; font-size: 14px; }
+    .meta { font-size: 13px; color: #71717a; margin-bottom: 16px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="card">
+      <div class="header">
+        <h1>⚡ ${APP_NAME}</h1>
+      </div>
+      ${content}
+    </div>
+    <div class="footer">
+      <p>Powered by <a href="${APP_URL}">${APP_NAME}</a></p>
+      <p>Please reply to this email to update your ticket.</p>
+    </div>
+  </div>
+</body>
+</html>`.trim();
+}
+
+function statusBadge(status: string): string {
+  const lower = status.toLowerCase();
+  let cls = 'badge-new';
+  if (lower.includes('active') || lower.includes('progress')) cls = 'badge-active';
+  else if (lower.includes('resolved') || lower.includes('done')) cls = 'badge-resolved';
+  else if (lower.includes('closed') || lower.includes('removed')) cls = 'badge-closed';
+  return `<span class="badge ${cls}">${status}</span>`;
+}
+
+export function ticketConfirmationTemplate(opts: {
+  ticketId: number;
+  subject: string;
+  requesterName: string;
+}): string {
+  const ticketUrl = `${APP_URL}/tickets/${opts.ticketId}`;
+  return layoutWrapper(`
+    <p>Hi ${opts.requesterName || 'there'},</p>
+    <div class="content">
+      <p>We've received your request and created ticket <strong>#${opts.ticketId}</strong>.</p>
+      <p class="meta"><strong>Subject:</strong> ${opts.subject}</p>
+      <p>Our team will review your request and get back to you as soon as possible.</p>
+      <p style="text-align: center; margin-top: 24px;">
+        <a href="${ticketUrl}" class="btn">View Ticket #${opts.ticketId}</a>
+      </p>
+    </div>
+  `);
+}
+
+export function agentReplyTemplate(opts: {
+  ticketId: number;
+  agentName: string;
+  replyContent: string;
+  ticketUrl?: string;
+}): string {
+  const ticketUrl = opts.ticketUrl || `${APP_URL}/tickets/${opts.ticketId}`;
+  return layoutWrapper(`
+    <p class="meta">${opts.agentName} replied to ticket <strong>#${opts.ticketId}</strong>:</p>
+    <div class="content">
+      ${opts.replyContent}
+    </div>
+    <p style="text-align: center; margin-top: 24px;">
+      <a href="${ticketUrl}" class="btn">View Ticket #${opts.ticketId}</a>
+    </p>
+  `);
+}
+
+export function statusChangeTemplate(opts: {
+  ticketId: number;
+  subject: string;
+  requesterName: string;
+  oldStatus: string;
+  newStatus: string;
+}): string {
+  const ticketUrl = `${APP_URL}/tickets/${opts.ticketId}`;
+  return layoutWrapper(`
+    <p>Hi ${opts.requesterName || 'there'},</p>
+    <div class="content">
+      <p>The status of your ticket <strong>#${opts.ticketId}</strong> has been updated:</p>
+      <p style="text-align: center; font-size: 16px;">
+        ${statusBadge(opts.oldStatus)} &rarr; ${statusBadge(opts.newStatus)}
+      </p>
+      <p class="meta"><strong>Subject:</strong> ${opts.subject}</p>
+      <p style="text-align: center; margin-top: 24px;">
+        <a href="${ticketUrl}" class="btn">View Ticket #${opts.ticketId}</a>
+      </p>
+    </div>
+  `);
+}

--- a/src/lib/email-templates.ts
+++ b/src/lib/email-templates.ts
@@ -77,11 +77,46 @@ export function ticketConfirmationTemplate(opts: {
   `);
 }
 
+export interface HistoryEntry {
+  authorName: string;
+  createdAt: Date;
+  contentHtml: string;
+}
+
+function renderHistory(history: HistoryEntry[]): string {
+  if (!history || history.length === 0) return '';
+  const items = history
+    .map((h) => {
+      const when = h.createdAt.toLocaleString('en-GB', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+      return `
+    <div style="border-left: 3px solid #d4d4d8; padding: 8px 12px; margin: 12px 0; color: #52525b; font-size: 13px;">
+      <p style="margin: 0 0 6px; color: #71717a; font-size: 12px;">
+        <strong>${h.authorName}</strong> · ${when}
+      </p>
+      <div>${h.contentHtml}</div>
+    </div>`;
+    })
+    .join('');
+  return `
+    <hr style="margin: 24px 0; border: none; border-top: 1px solid #e4e4e7;" />
+    <p class="meta" style="font-size: 12px; color: #71717a; margin-bottom: 4px;">
+      Earlier in this conversation:
+    </p>
+    ${items}`;
+}
+
 export function agentReplyTemplate(opts: {
   ticketId: number;
   agentName: string;
   replyContent: string;
   ticketUrl?: string;
+  history?: HistoryEntry[];
 }): string {
   const ticketUrl = opts.ticketUrl || `${APP_URL}/tickets/${opts.ticketId}`;
   return layoutWrapper(`
@@ -92,6 +127,7 @@ export function agentReplyTemplate(opts: {
     <p style="text-align: center; margin-top: 24px;">
       <a href="${ticketUrl}" class="btn">View Ticket #${opts.ticketId}</a>
     </p>
+    ${renderHistory(opts.history || [])}
   `);
 }
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -11,6 +11,7 @@ import {
   ticketConfirmationTemplate,
   agentReplyTemplate,
   statusChangeTemplate,
+  type HistoryEntry,
 } from './email-templates';
 
 const GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
@@ -183,12 +184,13 @@ export async function sendAgentReply(
   requesterEmail: string,
   agentName: string,
   replyHtml: string,
-  originalMessageId?: string
+  originalMessageId?: string,
+  history?: HistoryEntry[]
 ): Promise<void> {
   if (!isEmailConfigured()) return;
   try {
     const messageId = generateMessageId(ticketId);
-    const html = agentReplyTemplate({ ticketId, agentName, replyContent: replyHtml });
+    const html = agentReplyTemplate({ ticketId, agentName, replyContent: replyHtml, history });
     await sendViaGraph({
       to: requesterEmail,
       subject: threadedSubject(ticketId, `Re: ${subject}`),

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,258 @@
+/**
+ * Email service for ZapDesk — outbound mail and shared helpers.
+ *
+ * Outbound uses Microsoft Graph `sendMail` against a shared mailbox. Auth uses a
+ * dedicated Azure AD app (`MAIL_CLIENT_ID` / `MAIL_CLIENT_SECRET`) so the mail
+ * permission can be scoped independently of the main sign-in app. Falls back to
+ * the main app credentials when the dedicated ones are not set.
+ */
+
+import {
+  ticketConfirmationTemplate,
+  agentReplyTemplate,
+  statusChangeTemplate,
+} from './email-templates';
+
+const GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
+
+const MAIL_FROM = () => process.env.MAIL_FROM || '';
+const MAIL_FROM_NAME = () => process.env.MAIL_FROM_NAME || 'ZapDesk Support';
+
+function mailClientId(): string {
+  return process.env.MAIL_CLIENT_ID || process.env.AZURE_AD_CLIENT_ID || '';
+}
+function mailClientSecret(): string {
+  return process.env.MAIL_CLIENT_SECRET || process.env.AZURE_AD_CLIENT_SECRET || '';
+}
+function mailTenantId(): string {
+  return process.env.MAIL_TENANT_ID || process.env.AZURE_AD_TENANT_ID || '';
+}
+
+/** Outbound is configured when we have a from address and Graph credentials. */
+export function isEmailConfigured(): boolean {
+  return Boolean(MAIL_FROM() && mailClientId() && mailClientSecret() && mailTenantId());
+}
+
+/** Acquire a Graph token via client-credentials flow. Used by send + poll. */
+export async function getMailGraphToken(): Promise<string> {
+  const url = `https://login.microsoftonline.com/${mailTenantId()}/oauth2/v2.0/token`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: mailClientId(),
+      client_secret: mailClientSecret(),
+      grant_type: 'client_credentials',
+      scope: 'https://graph.microsoft.com/.default',
+    }),
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(`Failed to get mail Graph token: ${JSON.stringify(data)}`);
+  }
+  return data.access_token;
+}
+
+// ---------------------------------------------------------------------------
+// Tag helpers — requester email is stored on the work item as `email-from:<addr>`
+// ---------------------------------------------------------------------------
+
+export function isEmailTicket(tags: string | string[]): boolean {
+  const tagStr = Array.isArray(tags) ? tags.join('; ') : tags;
+  return tagStr.toLowerCase().includes('email');
+}
+
+export function extractRequesterEmail(tags: string | string[]): string | null {
+  const tagList = Array.isArray(tags) ? tags : tags.split(';').map((t) => t.trim());
+  for (const tag of tagList) {
+    const trimmed = tag.trim();
+    if (trimmed.toLowerCase().startsWith('email-from:')) {
+      return trimmed.slice('email-from:'.length).trim();
+    }
+  }
+  return null;
+}
+
+function nameFromEmail(email: string): string {
+  const local = email.split('@')[0];
+  return local.replace(/[._-]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// ---------------------------------------------------------------------------
+// Threading helpers — `[ZapDesk #N]` subject prefix works across every client
+// ---------------------------------------------------------------------------
+
+const MAIL_DOMAIN = () => MAIL_FROM().split('@')[1] || 'zapdesk.local';
+
+export function generateMessageId(ticketId: number, suffix?: string): string {
+  const part = suffix ? `${ticketId}-${suffix}` : `${ticketId}-${Date.now()}`;
+  return `<zapdesk-${part}@${MAIL_DOMAIN()}>`;
+}
+
+function threadedSubject(ticketId: number, subject: string): string {
+  const prefix = `[ZapDesk #${ticketId}]`;
+  if (subject.includes(prefix)) return subject;
+  return `${prefix} ${subject}`;
+}
+
+// ---------------------------------------------------------------------------
+// Graph send
+// ---------------------------------------------------------------------------
+
+interface GraphSendMailOptions {
+  to: string;
+  subject: string;
+  html: string;
+  messageId?: string;
+  inReplyTo?: string;
+}
+
+async function sendViaGraph(options: GraphSendMailOptions): Promise<void> {
+  const token = await getMailGraphToken();
+  const from = MAIL_FROM();
+
+  const message: Record<string, unknown> = {
+    subject: options.subject,
+    body: { contentType: 'HTML', content: options.html },
+    from: { emailAddress: { address: from, name: MAIL_FROM_NAME() } },
+    toRecipients: [{ emailAddress: { address: options.to } }],
+  };
+
+  if (options.inReplyTo) {
+    message.internetMessageHeaders = [
+      { name: 'In-Reply-To', value: options.inReplyTo },
+      { name: 'References', value: options.inReplyTo },
+    ];
+  }
+  if (options.messageId) {
+    const headers =
+      (message.internetMessageHeaders as Array<{ name: string; value: string }>) || [];
+    headers.push({ name: 'X-ZapDesk-MessageId', value: options.messageId });
+    message.internetMessageHeaders = headers;
+  }
+
+  const response = await fetch(`${GRAPH_BASE_URL}/users/${encodeURIComponent(from)}/sendMail`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ message, saveToSentItems: false }),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`Graph sendMail failed (${response.status}): ${errorBody}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Send functions — log on failure, never throw (callers are usually fire-and-forget)
+// ---------------------------------------------------------------------------
+
+export async function sendTicketConfirmation(
+  ticketId: number,
+  subject: string,
+  requesterEmail: string
+): Promise<string | null> {
+  if (!isEmailConfigured()) return null;
+  try {
+    const messageId = generateMessageId(ticketId, 'created');
+    const html = ticketConfirmationTemplate({
+      ticketId,
+      subject,
+      requesterName: nameFromEmail(requesterEmail),
+    });
+    await sendViaGraph({
+      to: requesterEmail,
+      subject: threadedSubject(ticketId, subject),
+      html,
+      messageId,
+    });
+    console.log(`[Email] Confirmation sent for ticket #${ticketId} to ${requesterEmail}`);
+    return messageId;
+  } catch (error) {
+    console.error(`[Email] Failed to send confirmation for ticket #${ticketId}:`, error);
+    return null;
+  }
+}
+
+export async function sendAgentReply(
+  ticketId: number,
+  subject: string,
+  requesterEmail: string,
+  agentName: string,
+  replyHtml: string,
+  originalMessageId?: string
+): Promise<void> {
+  if (!isEmailConfigured()) return;
+  try {
+    const messageId = generateMessageId(ticketId);
+    const html = agentReplyTemplate({ ticketId, agentName, replyContent: replyHtml });
+    await sendViaGraph({
+      to: requesterEmail,
+      subject: threadedSubject(ticketId, `Re: ${subject}`),
+      html,
+      messageId,
+      inReplyTo: originalMessageId,
+    });
+    console.log(`[Email] Agent reply sent for ticket #${ticketId} to ${requesterEmail}`);
+  } catch (error) {
+    console.error(`[Email] Failed to send agent reply for ticket #${ticketId}:`, error);
+  }
+}
+
+export async function sendStatusChangeNotification(
+  ticketId: number,
+  subject: string,
+  requesterEmail: string,
+  oldStatus: string,
+  newStatus: string,
+  originalMessageId?: string
+): Promise<void> {
+  if (!isEmailConfigured()) return;
+  try {
+    const messageId = generateMessageId(ticketId);
+    const html = statusChangeTemplate({
+      ticketId,
+      subject,
+      requesterName: nameFromEmail(requesterEmail),
+      oldStatus,
+      newStatus,
+    });
+    await sendViaGraph({
+      to: requesterEmail,
+      subject: threadedSubject(ticketId, `Re: ${subject}`),
+      html,
+      messageId,
+      inReplyTo: originalMessageId,
+    });
+    console.log(
+      `[Email] Status change notification sent for ticket #${ticketId} to ${requesterEmail}`
+    );
+  } catch (error) {
+    console.error(
+      `[Email] Failed to send status change notification for ticket #${ticketId}:`,
+      error
+    );
+  }
+}
+
+export async function sendTestEmail(to: string): Promise<void> {
+  const from = MAIL_FROM();
+  const html = `
+<div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 500px; margin: 0 auto; padding: 24px;">
+  <div style="background: #ffffff; border-radius: 8px; padding: 24px; border: 1px solid #e4e4e7;">
+    <h2 style="color: #22c55e; text-align: center; margin-top: 0;">⚡ ZapDesk</h2>
+    <p style="color: #18181b; line-height: 1.6;">This is a test email from your ZapDesk instance.</p>
+    <p style="color: #18181b; line-height: 1.6;">If you received this, your email configuration is working correctly.</p>
+    <div style="margin-top: 16px; padding: 12px; background: #f4f4f5; border-radius: 6px; font-size: 13px; color: #71717a;">
+      <strong>Method:</strong> Microsoft Graph API<br/>
+      <strong>From:</strong> ${from}<br/>
+      <strong>Sent at:</strong> ${new Date().toISOString()}
+    </div>
+  </div>
+</div>`.trim();
+
+  await sendViaGraph({ to, subject: 'ZapDesk — Test Email', html });
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -34,24 +34,57 @@ export function isEmailConfigured(): boolean {
   return Boolean(MAIL_FROM() && mailClientId() && mailClientSecret() && mailTenantId());
 }
 
+// In-module Graph token cache. Tokens last ~60 minutes; caching avoids hitting
+// the AAD token endpoint on every send / poll, which adds latency and risks
+// throttling under bursty traffic. Keyed on tenant+client so a config change
+// invalidates automatically.
+interface CachedToken {
+  key: string;
+  accessToken: string;
+  expiresAt: number;
+}
+let tokenCache: CachedToken | null = null;
+let inFlight: Promise<string> | null = null;
+const TOKEN_REFRESH_LEEWAY_MS = 60_000;
+
 /** Acquire a Graph token via client-credentials flow. Used by send + poll. */
 export async function getMailGraphToken(): Promise<string> {
-  const url = `https://login.microsoftonline.com/${mailTenantId()}/oauth2/v2.0/token`;
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      client_id: mailClientId(),
-      client_secret: mailClientSecret(),
-      grant_type: 'client_credentials',
-      scope: 'https://graph.microsoft.com/.default',
-    }),
-  });
-  const data = await response.json();
-  if (!response.ok) {
-    throw new Error(`Failed to get mail Graph token: ${JSON.stringify(data)}`);
+  const key = `${mailTenantId()}|${mailClientId()}`;
+  const now = Date.now();
+  if (tokenCache && tokenCache.key === key && tokenCache.expiresAt - TOKEN_REFRESH_LEEWAY_MS > now) {
+    return tokenCache.accessToken;
   }
-  return data.access_token;
+  if (inFlight) return inFlight;
+
+  inFlight = (async () => {
+    try {
+      const url = `https://login.microsoftonline.com/${mailTenantId()}/oauth2/v2.0/token`;
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          client_id: mailClientId(),
+          client_secret: mailClientSecret(),
+          grant_type: 'client_credentials',
+          scope: 'https://graph.microsoft.com/.default',
+        }),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(`Failed to get mail Graph token: ${JSON.stringify(data)}`);
+      }
+      const expiresInSec = typeof data.expires_in === 'number' ? data.expires_in : 3600;
+      tokenCache = {
+        key,
+        accessToken: data.access_token,
+        expiresAt: Date.now() + expiresInSec * 1000,
+      };
+      return data.access_token as string;
+    } finally {
+      inFlight = null;
+    }
+  })();
+  return inFlight;
 }
 
 // ---------------------------------------------------------------------------
@@ -59,8 +92,8 @@ export async function getMailGraphToken(): Promise<string> {
 // ---------------------------------------------------------------------------
 
 export function isEmailTicket(tags: string | string[]): boolean {
-  const tagStr = Array.isArray(tags) ? tags.join('; ') : tags;
-  return tagStr.toLowerCase().includes('email');
+  const tagList = Array.isArray(tags) ? tags : tags.split(';');
+  return tagList.some((t) => t.trim().toLowerCase() === 'email');
 }
 
 export function extractRequesterEmail(tags: string | string[]): string | null {

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -51,7 +51,11 @@ const TOKEN_REFRESH_LEEWAY_MS = 60_000;
 export async function getMailGraphToken(): Promise<string> {
   const key = `${mailTenantId()}|${mailClientId()}`;
   const now = Date.now();
-  if (tokenCache && tokenCache.key === key && tokenCache.expiresAt - TOKEN_REFRESH_LEEWAY_MS > now) {
+  if (
+    tokenCache &&
+    tokenCache.key === key &&
+    tokenCache.expiresAt - TOKEN_REFRESH_LEEWAY_MS > now
+  ) {
     return tokenCache.accessToken;
   }
   if (inFlight) return inFlight;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "scripts"]
 }


### PR DESCRIPTION
## Summary

Replaces the abandoned subscription-based design (closed [#303](https://github.com/knowall-ai/zapdesk/pull/303)) with a simpler 1-minute polling cron that drains a shared support mailbox via Microsoft Graph. Customers email the support address → ZapDesk creates a DevOps work item, sends a confirmation, and threads any reply back to the same ticket as a comment. Agent-side comments and state changes on email-tagged tickets fire outbound notifications, with full conversation history included.

Fixes #55. Likely closes #359 once merged.

## Why polling, not subscriptions

| | Subscription (PR #303) | Polling (this PR) |
|---|---|---|
| Real-time | ~5 sec | up to 60 sec |
| Expires & must be renewed | yes (every 70 h) | no |
| Public webhook URL contract | yes (validation handshake, clientState) | no — outbound calls only |
| Failure mode | dies silently → no email detected | one cron miss → next run picks up |
| Lines of code | ~400 | ~80 (poll only) |

For B2B support, 60-second latency is invisible. The brittleness of expiring subscriptions is not.

## Architecture

\`\`\`
Customer ──email──> support mailbox (Exchange Online)
                         ↑
                         │  Graph poll every minute (GitHub Actions cron)
ZapDesk /api/email/poll ─┘
       │
       ├─ subject contains [ZapDesk #N]?
       │     yes → add comment to ticket #N
       │     no  → create ticket; route to project by sender domain
       │
       └─ Graph sendMail → Customer (confirmation / reply / status change)
\`\`\`

## What's in the PR

**Inbound**
- \`src/lib/email-poll.ts\` — list unread (newest-first), ingest, mark read, fetch attachments
- \`src/app/api/email/poll/route.ts\` — secret-protected cron endpoint (\`x-webhook-secret\`)
- \`src/app/api/email/webhook/route.ts\` — push fallback for forwarders (Power Automate / Logic App / SendGrid Inbound), routes through the same ingest pipeline
- \`src/lib/email-ingest.ts\` — domain → project routing, \`[ZapDesk #N]\` thread detection, ticket / comment creation with PAT, attachment upload
- \`src/lib/email-clean.ts\` — uses Graph \`uniqueBody\` (text) + RFC \`-- \` signature delimiter heuristic + confidentiality-notice stripping + HTML escape (closes XSS path on inbound HTML)

**Outbound**
- \`src/lib/email.ts\` — Graph token (client credentials), \`sendMail\`, threading helpers, \`email-from:\` tag helpers
- \`src/lib/email-templates.ts\` — branded HTML for confirmation / agent reply / status change, with \`renderHistory\` for threaded replies
- Comments + state APIs fire-and-forget notify the requester on email-tagged tickets — outbound never blocks ticket ops
- **Agent reply emails include the full conversation history**: new reply on top, divider, prior comments newest-first, original ticket description at the bottom (commit \`f2deb86\`)

**Ops & docs**
- \`.github/workflows/email-poll.yml\` — cron driving the poller (\`*/5 * * * *\`; switch to \`* * * * *\` on paid runners for 1-minute latency)
- \`src/app/admin/page.tsx\` — Email Channel section: outbound + inbound status, send-test
- \`scripts/check-domain-mapping.ts\`, \`check-mailbox-access.ts\`, \`trigger-poll.ts\` — operator diagnostics
- \`docs/EMAIL_SETUP.adoc\` — \`Mail.Send\` + \`Mail.ReadWrite\` app perms, Application Access Policy scoping, env vars, GitHub secrets

## Required configuration

**Azure AD mail app** (Application permissions, admin consent):
- \`Mail.Send\` — outbound
- \`Mail.ReadWrite\` — inbound (list unread + flag-as-read)

**Application Access Policy** restricting the app to the support mailbox only:

\`\`\`powershell
New-ApplicationAccessPolicy -AppId <APP_ID> \`
  -PolicyScopeGroupId support@yourdomain.com \`
  -AccessRight RestrictAccess \`
  -Description \"ZapDesk inbound + outbound\"
\`\`\`

**App env vars**: \`MAIL_TENANT_ID\`, \`MAIL_CLIENT_ID\`, \`MAIL_CLIENT_SECRET\`, \`MAIL_FROM\`, \`MAIL_POLL_MAILBOX\`, \`EMAIL_WEBHOOK_SECRET\`, \`AZURE_DEVOPS_PAT\`.
**Repo secrets** (for the cron): \`ZAPDESK_BASE_URL\`, \`EMAIL_WEBHOOK_SECRET\`.

## Verified end-to-end

Tested locally against a fresh shared mailbox (\`supporttest@knowall.ai\`):

- [x] New ticket from email — routed to correct DevOps project by sender domain (\`knowall.ai\` → Internal)
- [x] Confirmation email delivered with \`[ZapDesk #N]\` subject prefix
- [x] Reply with \`[ZapDesk #N]\` in subject → comment appended to existing ticket (no duplicate)
- [x] Inbound HTML signatures + quoted threads stripped (\`uniqueBody\` + \`-- \` delimiter)
- [x] Newest-first poll ordering — backlog of unrouteable mail no longer blocks new arrivals
- [x] Agent comment in UI on email-tagged ticket → email lands in customer inbox
- [x] Agent reply email contains full history (prior comments newest-first + original description)
- [x] HTML XSS path closed via escaping on inbound rendering

## Follow-ups (tracked separately)

Items raised during the E2E test session that are out-of-scope for this PR:

- **#359** — Email replies to customer should include full ticket history *(likely closed by this PR — verify on merge)*
- **#360** — Notify agents when a customer replies on an email-tagged ticket
- **#361** — Brand outbound emails with ZapDesk UI styling + ZapDesk and KnowAll AI logos
- **#362** — Inbound attachments / pasted screenshots not landing on the created ticket *(bug — \`isInline\` filter drops them)*

## Known gaps (not blocking merge)

- Inbox cleanup: messages that fail with \`No project mapping\` stay unread forever. Future: auto-mark-read on this specific failure to drain noise, while keeping retries for transient errors.
- Polling interval limited to 5 minutes on the free GitHub Actions tier — paid runners can go to 1-minute. Alternative: an Azure WebJob or App Service \`AlwaysOn\` background task.

## Test plan for reviewer

- [x] Send fresh email from a mapped domain → ticket appears in expected project, confirmation arrives
- [x] Reply to confirmation → comment appended, no duplicate ticket
- [x] Agent comment on email-tagged ticket → email lands in customer inbox with history
- [x] Agent state change on email-tagged ticket → status-change email lands in customer inbox
- [x] Send email from an unmapped sender domain → \`No project mapping found\` (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

