### PR TITLE
feat: add parent work item picker when creating items in Kanban

### DIFF
--- a/src/app/api/devops/projects/[project]/parent-candidates/route.ts
+++ b/src/app/api/devops/projects/[project]/parent-candidates/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { AzureDevOpsService } from '@/lib/devops';
+import { validateOrganizationAccess } from '@/lib/devops-auth';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ project: string }> }
+) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.accessToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const organization = request.headers.get('x-devops-org');
+    if (!organization) {
+      return NextResponse.json({ error: 'No organization specified' }, { status: 400 });
+    }
+
+    const hasAccess = await validateOrganizationAccess(session.accessToken, organization);
+    if (!hasAccess) {
+      return NextResponse.json(
+        { error: 'Access denied to the specified organization' },
+        { status: 403 }
+      );
+    }
+
+    const { project } = await params;
+    const projectName = decodeURIComponent(project);
+
+    const devopsService = new AzureDevOpsService(session.accessToken, organization);
+    const candidates = await devopsService.getPotentialParents(projectName);
+
+    return NextResponse.json({ candidates });
+  } catch (error) {
+    console.error('Error fetching parent candidates:', error);
+    return NextResponse.json({ error: 'Failed to fetch parent candidates' }, { status: 500 });
+  }
+}

--- a/src/app/api/devops/tickets/route.ts
+++ b/src/app/api/devops/tickets/route.ts
@@ -106,6 +106,7 @@ export async function POST(request: NextRequest) {
       iterationPath,
       areaPath,
       additionalFields,
+      parentId,
     } = body;
 
     if (!project || !title) {
@@ -170,6 +171,12 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // Validate parentId — must be a positive integer to avoid arbitrary URL injection
+    const validatedParentId =
+      typeof parentId === 'number' && Number.isInteger(parentId) && parentId > 0
+        ? parentId
+        : undefined;
+
     // Create the ticket with 'ticket' tag always included
     const allTags = ['ticket', ...(tags || [])].filter(Boolean);
     const workItem = await devopsService.createTicketWithAssignee(
@@ -186,6 +193,7 @@ export async function POST(request: NextRequest) {
         additionalFields: validatedAdditionalFields,
         iterationPath: typeof iterationPath === 'string' ? iterationPath : undefined,
         areaPath: typeof areaPath === 'string' ? areaPath : undefined,
+        parentId: validatedParentId,
       }
     );
 

--- a/src/components/tickets/NewTicketDialog.tsx
+++ b/src/components/tickets/NewTicketDialog.tsx
@@ -24,6 +24,20 @@ interface RequiredField {
   allowedValues?: string[];
 }
 
+interface ParentCandidate {
+  id: number;
+  title: string;
+  workItemType: string;
+  state: string;
+  areaPath: string;
+  parentId?: number;
+}
+
+// Story-equivalents across templates (Agile / Scrum / CMMI). The picker
+// surfaces them all under the "Story" tier so users don't need to know
+// which template their project uses.
+const STORY_TYPES = ['User Story', 'Product Backlog Item', 'Requirement'];
+
 interface NewTicketForm {
   project: string;
   title: string;
@@ -74,6 +88,14 @@ export default function NewTicketDialog({ isOpen, onClose }: NewTicketDialogProp
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [foundBySearch, setFoundBySearch] = useState('');
+
+  // Parent picker state — three cascading levels (Epic → Feature → Story).
+  // The actual parent linked is the most specific selection (story > feature > epic).
+  const [parentCandidates, setParentCandidates] = useState<ParentCandidate[]>([]);
+  const [isLoadingParents, setIsLoadingParents] = useState(false);
+  const [selectedEpicId, setSelectedEpicId] = useState<number | null>(null);
+  const [selectedFeatureId, setSelectedFeatureId] = useState<number | null>(null);
+  const [selectedStoryId, setSelectedStoryId] = useState<number | null>(null);
 
   const [form, setForm] = useState<NewTicketForm>({
     project: '',
@@ -252,6 +274,27 @@ export default function NewTicketDialog({ isOpen, onClose }: NewTicketDialogProp
     [get]
   );
 
+  const fetchParentCandidates = useCallback(
+    async (projectName: string) => {
+      setIsLoadingParents(true);
+      try {
+        const response = await get(
+          `/api/devops/projects/${encodeURIComponent(projectName)}/parent-candidates`
+        );
+        if (!response.ok) throw new Error('Failed to fetch parent candidates');
+        const data = await response.json();
+        setParentCandidates(data.candidates || []);
+      } catch (err) {
+        // Picker is optional — degrade silently to no candidates
+        console.error('Failed to fetch parent candidates:', err);
+        setParentCandidates([]);
+      } finally {
+        setIsLoadingParents(false);
+      }
+    },
+    [get]
+  );
+
   // Reset form when dialog opens
   useEffect(() => {
     if (isOpen) {
@@ -279,6 +322,10 @@ export default function NewTicketDialog({ isOpen, onClose }: NewTicketDialogProp
       setPendingFiles([]);
       setRequiredFields([]);
       setAdditionalFieldValues({});
+      setParentCandidates([]);
+      setSelectedEpicId(null);
+      setSelectedFeatureId(null);
+      setSelectedStoryId(null);
     }
   }, [isOpen]);
 
@@ -296,12 +343,18 @@ export default function NewTicketDialog({ isOpen, onClose }: NewTicketDialogProp
       fetchWorkItemTypes(form.project);
       fetchIterations(form.project);
       fetchAreas(form.project);
+      fetchParentCandidates(form.project);
     } else {
       setTeamMembers([]);
       setWorkItemTypes([]);
       setIterations([]);
       setAreas([]);
+      setParentCandidates([]);
     }
+    // Clear selected parent when project changes
+    setSelectedEpicId(null);
+    setSelectedFeatureId(null);
+    setSelectedStoryId(null);
   }, [
     form.project,
     session,
@@ -310,6 +363,7 @@ export default function NewTicketDialog({ isOpen, onClose }: NewTicketDialogProp
     fetchWorkItemTypes,
     fetchIterations,
     fetchAreas,
+    fetchParentCandidates,
   ]);
 
   // Fetch priorities when project or work item type changes
@@ -362,6 +416,40 @@ export default function NewTicketDialog({ isOpen, onClose }: NewTicketDialogProp
       })
       .sort((a, b) => a.displayName.localeCompare(b.displayName));
   }, [teamMembers, foundBySearch]);
+
+  // Group candidates by tier and apply cascading filter rules.
+  const sortByTitle = (a: ParentCandidate, b: ParentCandidate) => a.title.localeCompare(b.title);
+
+  const epics = useMemo(
+    () => parentCandidates.filter((p) => p.workItemType === 'Epic').sort(sortByTitle),
+    [parentCandidates]
+  );
+
+  const features = useMemo(() => {
+    const all = parentCandidates.filter((p) => p.workItemType === 'Feature');
+    const filtered = selectedEpicId ? all.filter((f) => f.parentId === selectedEpicId) : all;
+    return filtered.sort(sortByTitle);
+  }, [parentCandidates, selectedEpicId]);
+
+  const stories = useMemo(() => {
+    const all = parentCandidates.filter((p) => STORY_TYPES.includes(p.workItemType));
+    let filtered = all;
+    if (selectedFeatureId) {
+      filtered = all.filter((s) => s.parentId === selectedFeatureId);
+    } else if (selectedEpicId) {
+      // No Feature picked yet — surface stories whose Feature parent rolls up to the chosen Epic.
+      const featureIdsUnderEpic = new Set(
+        parentCandidates
+          .filter((p) => p.workItemType === 'Feature' && p.parentId === selectedEpicId)
+          .map((f) => f.id)
+      );
+      filtered = all.filter((s) => s.parentId && featureIdsUnderEpic.has(s.parentId));
+    }
+    return filtered.sort(sortByTitle);
+  }, [parentCandidates, selectedFeatureId, selectedEpicId]);
+
+  // Most-specific selection wins. This is the parent that gets linked on submit.
+  const effectiveParentId = selectedStoryId ?? selectedFeatureId ?? selectedEpicId ?? null;
 
   // Filter out Stakeholders and apply search
   const filteredMembers = useMemo(() => {
@@ -466,6 +554,7 @@ export default function NewTicketDialog({ isOpen, onClose }: NewTicketDialogProp
           .map((t) => t.trim())
           .filter(Boolean),
         additionalFields: Object.keys(additionalFields).length > 0 ? additionalFields : undefined,
+        parentId: effectiveParentId ?? undefined,
       });
 
       if (!response.ok) {
@@ -1084,6 +1173,121 @@ export default function NewTicketDialog({ isOpen, onClose }: NewTicketDialogProp
                   </select>
                 )}
               </div>
+
+              {/* Parent (optional) — cascading Epic → Feature → Story.
+                  The most specific selection becomes the linked parent. */}
+              {isLoadingParents ? (
+                <div>
+                  <label
+                    className="mb-1 block text-xs uppercase"
+                    style={{ color: 'var(--text-muted)' }}
+                  >
+                    Parent
+                  </label>
+                  <div
+                    className="flex items-center gap-2 text-sm"
+                    style={{ color: 'var(--text-muted)' }}
+                  >
+                    <Loader2 className="animate-spin" size={14} />
+                    Loading...
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <div>
+                    <label
+                      className="mb-1 block text-xs uppercase"
+                      style={{ color: 'var(--text-muted)' }}
+                    >
+                      Epic
+                    </label>
+                    <select
+                      value={selectedEpicId ?? ''}
+                      onChange={(e) => {
+                        const id = e.target.value ? parseInt(e.target.value, 10) : null;
+                        setSelectedEpicId(id);
+                        // Cascading reset — narrower selections may no longer fit
+                        setSelectedFeatureId(null);
+                        setSelectedStoryId(null);
+                      }}
+                      className="input w-full"
+                      disabled={!form.project || epics.length === 0}
+                    >
+                      <option value="">{epics.length === 0 ? 'No Epics available' : 'None'}</option>
+                      {epics.map((epic) => (
+                        <option key={epic.id} value={epic.id}>
+                          #{epic.id} {epic.title}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div>
+                    <label
+                      className="mb-1 block text-xs uppercase"
+                      style={{ color: 'var(--text-muted)' }}
+                    >
+                      Feature
+                    </label>
+                    <select
+                      value={selectedFeatureId ?? ''}
+                      onChange={(e) => {
+                        const id = e.target.value ? parseInt(e.target.value, 10) : null;
+                        setSelectedFeatureId(id);
+                        setSelectedStoryId(null);
+                      }}
+                      className="input w-full"
+                      disabled={!form.project || features.length === 0}
+                    >
+                      <option value="">
+                        {features.length === 0
+                          ? selectedEpicId
+                            ? 'No Features under this Epic'
+                            : 'No Features available'
+                          : 'None'}
+                      </option>
+                      {features.map((feature) => (
+                        <option key={feature.id} value={feature.id}>
+                          #{feature.id} {feature.title}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div>
+                    <label
+                      className="mb-1 block text-xs uppercase"
+                      style={{ color: 'var(--text-muted)' }}
+                    >
+                      User Story
+                    </label>
+                    <select
+                      value={selectedStoryId ?? ''}
+                      onChange={(e) => {
+                        const id = e.target.value ? parseInt(e.target.value, 10) : null;
+                        setSelectedStoryId(id);
+                      }}
+                      className="input w-full"
+                      disabled={!form.project || stories.length === 0}
+                    >
+                      <option value="">
+                        {stories.length === 0
+                          ? selectedFeatureId
+                            ? 'No Stories under this Feature'
+                            : selectedEpicId
+                              ? 'No Stories under this Epic'
+                              : 'No Stories available'
+                          : 'None'}
+                      </option>
+                      {stories.map((story) => (
+                        <option key={story.id} value={story.id}>
+                          #{story.id} {story.title}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </>
+              )}
 
               {/* Found By - people picker, shown only for Enhancement type */}
               {showFoundBy && (

--- a/src/components/tickets/NewTicketDialog.tsx
+++ b/src/components/tickets/NewTicketDialog.tsx
@@ -38,6 +38,9 @@ interface ParentCandidate {
 // which template their project uses.
 const STORY_TYPES = ['User Story', 'Product Backlog Item', 'Requirement'];
 
+// Module-scope so the reference is stable across renders (keeps useMemo deps clean).
+const sortByTitle = (a: ParentCandidate, b: ParentCandidate) => a.title.localeCompare(b.title);
+
 interface NewTicketForm {
   project: string;
   title: string;
@@ -418,8 +421,6 @@ export default function NewTicketDialog({ isOpen, onClose }: NewTicketDialogProp
   }, [teamMembers, foundBySearch]);
 
   // Group candidates by tier and apply cascading filter rules.
-  const sortByTitle = (a: ParentCandidate, b: ParentCandidate) => a.title.localeCompare(b.title);
-
   const epics = useMemo(
     () => parentCandidates.filter((p) => p.workItemType === 'Epic').sort(sortByTitle),
     [parentCandidates]
@@ -437,13 +438,19 @@ export default function NewTicketDialog({ isOpen, onClose }: NewTicketDialogProp
     if (selectedFeatureId) {
       filtered = all.filter((s) => s.parentId === selectedFeatureId);
     } else if (selectedEpicId) {
-      // No Feature picked yet — surface stories whose Feature parent rolls up to the chosen Epic.
+      // No Feature picked yet — surface stories rolling up to the chosen Epic.
+      // This includes both stories under an intermediate Feature and stories linked
+      // directly to the Epic (e.g. teams that skip the Feature tier).
       const featureIdsUnderEpic = new Set(
         parentCandidates
           .filter((p) => p.workItemType === 'Feature' && p.parentId === selectedEpicId)
           .map((f) => f.id)
       );
-      filtered = all.filter((s) => s.parentId && featureIdsUnderEpic.has(s.parentId));
+      filtered = all.filter(
+        (s) =>
+          s.parentId === selectedEpicId ||
+          (s.parentId !== undefined && featureIdsUnderEpic.has(s.parentId))
+      );
     }
     return filtered.sort(sortByTitle);
   }, [parentCandidates, selectedFeatureId, selectedEpicId]);
@@ -1259,7 +1266,7 @@ export default function NewTicketDialog({ isOpen, onClose }: NewTicketDialogProp
                       className="mb-1 block text-xs uppercase"
                       style={{ color: 'var(--text-muted)' }}
                     >
-                      User Story
+                      Story
                     </label>
                     <select
                       value={selectedStoryId ?? ''}

--- a/src/components/tickets/NewTicketModal.tsx
+++ b/src/components/tickets/NewTicketModal.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { useState } from 'react';
-import { X, Loader2 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { X, Loader2, Search } from 'lucide-react';
+import { useDevOpsApi } from '@/hooks';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import type { TicketType } from '@/types';
 
 interface NewTicketModalProps {
@@ -11,18 +13,83 @@ interface NewTicketModalProps {
   onTicketCreated: () => void;
 }
 
+interface ParentCandidate {
+  id: number;
+  title: string;
+  workItemType: string;
+  state: string;
+  areaPath: string;
+}
+
 export function NewTicketModal({
   isOpen,
   onClose,
   projectName,
   onTicketCreated,
 }: NewTicketModalProps) {
+  const { get: devOpsGet, post: devOpsPost, hasOrganization } = useDevOpsApi();
+
   const [ticketType, setTicketType] = useState<TicketType>('Feature');
   const [subject, setSubject] = useState('');
   const [description, setDescription] = useState('');
   const [priority, setPriority] = useState(3);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Parent picker state
+  const [parentCandidates, setParentCandidates] = useState<ParentCandidate[]>([]);
+  const [isLoadingParents, setIsLoadingParents] = useState(false);
+  const [parentSearch, setParentSearch] = useState('');
+  const [showParentDropdown, setShowParentDropdown] = useState(false);
+  const [selectedParent, setSelectedParent] = useState<ParentCandidate | null>(null);
+  const parentPickerRef = useClickOutside<HTMLDivElement>(() => setShowParentDropdown(false));
+
+  // Load parent candidates when the modal opens for a project
+  useEffect(() => {
+    if (!isOpen || !projectName || !hasOrganization) return;
+
+    let cancelled = false;
+    setIsLoadingParents(true);
+    devOpsGet(`/api/devops/projects/${encodeURIComponent(projectName)}/parent-candidates`)
+      .then(async (response) => {
+        if (!response.ok) return;
+        const data = (await response.json()) as { candidates?: ParentCandidate[] };
+        if (!cancelled) setParentCandidates(data.candidates || []);
+      })
+      .catch(() => {
+        // Picker is optional — silently degrade to no candidates on failure
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingParents(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, projectName, hasOrganization, devOpsGet]);
+
+  // Reset parent state whenever the modal closes or the project changes
+  useEffect(() => {
+    if (!isOpen) {
+      setSelectedParent(null);
+      setParentSearch('');
+      setShowParentDropdown(false);
+    }
+  }, [isOpen]);
+  useEffect(() => {
+    setSelectedParent(null);
+    setParentSearch('');
+  }, [projectName]);
+
+  const filteredParents = useMemo(() => {
+    const q = parentSearch.trim().toLowerCase();
+    const list = q
+      ? parentCandidates.filter(
+          (p) => p.title.toLowerCase().includes(q) || String(p.id).includes(q)
+        )
+      : parentCandidates;
+    return list.slice(0, 50);
+  }, [parentCandidates, parentSearch]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -40,16 +107,13 @@ export function NewTicketModal({
       // Strip any existing type prefix to prevent duplicates like "[Feature] [Feature]"
       const cleanSubject = subject.trim().replace(/^\[(Bug|Feature)\]\s*/i, '');
 
-      const response = await fetch('/api/devops/tickets', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          project: projectName,
-          title: `[${ticketType}] ${cleanSubject}`,
-          description: description.trim(),
-          priority,
-          tags,
-        }),
+      const response = await devOpsPost('/api/devops/tickets', {
+        project: projectName,
+        title: `[${ticketType}] ${cleanSubject}`,
+        description: description.trim(),
+        priority,
+        tags,
+        parentId: selectedParent?.id,
       });
 
       if (!response.ok) {
@@ -62,6 +126,8 @@ export function NewTicketModal({
       setDescription('');
       setPriority(3);
       setTicketType('Feature');
+      setSelectedParent(null);
+      setParentSearch('');
 
       onTicketCreated();
       onClose();
@@ -203,7 +269,7 @@ export function NewTicketModal({
           </div>
 
           {/* Priority */}
-          <div className="mb-6">
+          <div className="mb-4">
             <label className="mb-2 block text-xs uppercase" style={{ color: 'var(--text-muted)' }}>
               Priority
             </label>
@@ -224,6 +290,138 @@ export function NewTicketModal({
               <option value={3}>Normal</option>
               <option value={4}>Low</option>
             </select>
+          </div>
+
+          {/* Parent (optional) */}
+          <div className="mb-6" ref={parentPickerRef}>
+            <label className="mb-2 block text-xs uppercase" style={{ color: 'var(--text-muted)' }}>
+              Parent (optional)
+            </label>
+
+            {selectedParent ? (
+              <div
+                className="flex items-center justify-between rounded-md p-2 text-sm"
+                style={{
+                  backgroundColor: 'var(--background)',
+                  border: '1px solid var(--border)',
+                }}
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="rounded px-1.5 py-0.5 text-xs font-medium"
+                      style={{
+                        backgroundColor: 'var(--surface-hover)',
+                        color: 'var(--text-secondary)',
+                      }}
+                    >
+                      {selectedParent.workItemType}
+                    </span>
+                    <span
+                      className="truncate"
+                      style={{ color: 'var(--text-primary)' }}
+                      title={selectedParent.title}
+                    >
+                      #{selectedParent.id} {selectedParent.title}
+                    </span>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSelectedParent(null);
+                    setParentSearch('');
+                  }}
+                  className="ml-2 rounded p-1 hover:bg-[var(--surface-hover)]"
+                  style={{ color: 'var(--text-muted)' }}
+                  disabled={isSubmitting}
+                  aria-label="Clear parent"
+                >
+                  <X size={14} />
+                </button>
+              </div>
+            ) : (
+              <div className="relative">
+                <div className="relative">
+                  <Search
+                    size={14}
+                    className="absolute top-1/2 left-3 -translate-y-1/2"
+                    style={{ color: 'var(--text-muted)' }}
+                  />
+                  <input
+                    type="text"
+                    placeholder={
+                      isLoadingParents
+                        ? 'Loading parent items...'
+                        : parentCandidates.length === 0
+                          ? 'No parent items available'
+                          : 'Search Epics, Features, User Stories...'
+                    }
+                    value={parentSearch}
+                    onChange={(e) => {
+                      setParentSearch(e.target.value);
+                      setShowParentDropdown(true);
+                    }}
+                    onFocus={() => setShowParentDropdown(true)}
+                    className="input w-full pl-9"
+                    disabled={isSubmitting || isLoadingParents || parentCandidates.length === 0}
+                  />
+                </div>
+
+                {showParentDropdown && filteredParents.length > 0 && (
+                  <div
+                    className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md shadow-lg"
+                    style={{
+                      backgroundColor: 'var(--surface)',
+                      border: '1px solid var(--border)',
+                    }}
+                  >
+                    {filteredParents.map((candidate) => (
+                      <button
+                        key={candidate.id}
+                        type="button"
+                        onClick={() => {
+                          setSelectedParent(candidate);
+                          setShowParentDropdown(false);
+                          setParentSearch('');
+                        }}
+                        className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-[var(--surface-hover)]"
+                      >
+                        <span
+                          className="rounded px-1.5 py-0.5 text-xs font-medium"
+                          style={{
+                            backgroundColor: 'var(--background)',
+                            color: 'var(--text-secondary)',
+                          }}
+                        >
+                          {candidate.workItemType}
+                        </span>
+                        <span
+                          className="truncate"
+                          style={{ color: 'var(--text-primary)' }}
+                          title={candidate.title}
+                        >
+                          #{candidate.id} {candidate.title}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+
+                {showParentDropdown && parentSearch && filteredParents.length === 0 && (
+                  <div
+                    className="absolute z-10 mt-1 w-full rounded-md p-3 text-sm shadow-lg"
+                    style={{
+                      backgroundColor: 'var(--surface)',
+                      border: '1px solid var(--border)',
+                      color: 'var(--text-muted)',
+                    }}
+                  >
+                    No matches.
+                  </div>
+                )}
+              </div>
+            )}
           </div>
 
           {/* Project info */}

--- a/src/lib/devops.ts
+++ b/src/lib/devops.ts
@@ -1914,13 +1914,17 @@ export class AzureDevOpsService {
 
     // Need relations to derive each item's parent for cascade filtering;
     // $expand=relations is incompatible with the fields parameter, so we expand all.
+    // Fail loudly if any chunk request fails — a partial list would let users
+    // pick the wrong parent (or hide a valid one) without realising it.
     const all: Array<DevOpsWorkItem & { relations?: Array<{ rel: string; url: string }> }> = [];
     for (const chunk of chunks) {
       const detailsResponse = await fetch(
         `${this.baseUrl}/_apis/wit/workitems?ids=${chunk.join(',')}&$expand=relations&api-version=7.0`,
         { headers: this.headers }
       );
-      if (!detailsResponse.ok) continue;
+      if (!detailsResponse.ok) {
+        throw new Error(`Failed to fetch parent candidate details: ${detailsResponse.statusText}`);
+      }
       const detailsData = await detailsResponse.json();
       all.push(...(detailsData.value || []));
     }

--- a/src/lib/devops.ts
+++ b/src/lib/devops.ts
@@ -789,6 +789,7 @@ export class AzureDevOpsService {
       additionalFields?: Record<string, string | number>;
       iterationPath?: string;
       areaPath?: string;
+      parentId?: number;
     } = {}
   ): Promise<DevOpsWorkItem> {
     const {
@@ -801,6 +802,7 @@ export class AzureDevOpsService {
       additionalFields,
       iterationPath,
       areaPath,
+      parentId,
     } = options;
     const patchDocument: Array<{ op: string; path: string; value: string | number }> = [
       { op: 'add', path: '/fields/System.Title', value: title },
@@ -845,6 +847,23 @@ export class AzureDevOpsService {
       }
     }
 
+    // Optional parent link. Relations use a different value shape than fields,
+    // so they're appended outside patchDocument (which is reused on retry).
+    const parentRelation =
+      typeof parentId === 'number' && Number.isInteger(parentId) && parentId > 0
+        ? {
+            op: 'add',
+            path: '/relations/-',
+            value: {
+              rel: 'System.LinkTypes.Hierarchy-Reverse',
+              url: `${this.baseUrl}/_apis/wit/workItems/${parentId}`,
+            },
+          }
+        : null;
+    const buildBody = (
+      doc: Array<{ op: string; path: string; value: string | number }>
+    ): unknown[] => (parentRelation ? [...doc, parentRelation] : doc);
+
     const createUrl = `${this.baseUrl}/${encodeURIComponent(projectName)}/_apis/wit/workitems/$${workItemType}?api-version=7.0`;
     const createHeaders = {
       ...this.headers,
@@ -854,7 +873,7 @@ export class AzureDevOpsService {
     const response = await fetch(createUrl, {
       method: 'POST',
       headers: createHeaders,
-      body: JSON.stringify(patchDocument),
+      body: JSON.stringify(buildBody(patchDocument)),
     });
 
     if (!response.ok) {
@@ -871,7 +890,7 @@ export class AzureDevOpsService {
         const retryResponse = await fetch(createUrl, {
           method: 'POST',
           headers: createHeaders,
-          body: JSON.stringify(retryDoc),
+          body: JSON.stringify(buildBody(retryDoc)),
         });
         if (retryResponse.ok) {
           return retryResponse.json();
@@ -1840,6 +1859,92 @@ export class AzureDevOpsService {
     }
 
     return users;
+  }
+
+  // Get work items in a project that can be selected as a parent
+  // (Epic, Feature, User Story / Product Backlog Item / Requirement).
+  // Includes each item's parent ID so the UI can cascade-filter.
+  async getPotentialParents(projectName: string): Promise<
+    Array<{
+      id: number;
+      title: string;
+      workItemType: string;
+      state: string;
+      areaPath: string;
+      parentId?: number;
+    }>
+  > {
+    // Include backlog parent types from all common process templates:
+    // Agile (User Story), Scrum (Product Backlog Item), CMMI (Requirement),
+    // plus Epic and Feature which exist in all.
+    const wiql = {
+      query: `
+        SELECT [System.Id], [System.Title], [System.WorkItemType],
+               [System.State], [System.AreaPath]
+        FROM WorkItems
+        WHERE [System.TeamProject] = '${escapeWiql(projectName)}'
+          AND [System.WorkItemType] IN ('Epic', 'Feature', 'User Story', 'Product Backlog Item', 'Requirement')
+          AND [System.State] NOT IN ('Closed', 'Removed', 'Done', 'Completed', 'Cut')
+        ORDER BY [System.WorkItemType], [System.ChangedDate] DESC
+      `,
+    };
+
+    const queryResponse = await fetch(
+      `${this.baseUrl}/${encodeURIComponent(projectName)}/_apis/wit/wiql?api-version=7.0`,
+      {
+        method: 'POST',
+        headers: this.headers,
+        body: JSON.stringify(wiql),
+      }
+    );
+
+    if (!queryResponse.ok) {
+      throw new Error(`Failed to query parent candidates: ${queryResponse.statusText}`);
+    }
+
+    const queryData = await queryResponse.json();
+    const workItemIds: number[] = (queryData.workItems || []).map((wi: { id: number }) => wi.id);
+    if (workItemIds.length === 0) return [];
+
+    // Batch in chunks of 200 to stay under the DevOps URL/ID limit
+    const chunks: number[][] = [];
+    for (let i = 0; i < workItemIds.length; i += 200) {
+      chunks.push(workItemIds.slice(i, i + 200));
+    }
+
+    // Need relations to derive each item's parent for cascade filtering;
+    // $expand=relations is incompatible with the fields parameter, so we expand all.
+    const all: Array<DevOpsWorkItem & { relations?: Array<{ rel: string; url: string }> }> = [];
+    for (const chunk of chunks) {
+      const detailsResponse = await fetch(
+        `${this.baseUrl}/_apis/wit/workitems?ids=${chunk.join(',')}&$expand=relations&api-version=7.0`,
+        { headers: this.headers }
+      );
+      if (!detailsResponse.ok) continue;
+      const detailsData = await detailsResponse.json();
+      all.push(...(detailsData.value || []));
+    }
+
+    return all.map((wi) => {
+      let parentId: number | undefined;
+      for (const relation of wi.relations || []) {
+        if (relation.rel === 'System.LinkTypes.Hierarchy-Reverse' && relation.url) {
+          const idMatch = relation.url.match(/workItems\/(\d+)/);
+          if (idMatch) {
+            parentId = parseInt(idMatch[1], 10);
+            break;
+          }
+        }
+      }
+      return {
+        id: wi.id,
+        title: wi.fields['System.Title'],
+        workItemType: wi.fields['System.WorkItemType'],
+        state: wi.fields['System.State'],
+        areaPath: wi.fields['System.AreaPath'],
+        parentId,
+      };
+    });
   }
 
   // Get all Epics from a project


### PR DESCRIPTION
## Summary
- New cascading **Epic → Feature → User Story** picker in the +Add ticket dialog (`NewTicketDialog`). Selecting an Epic narrows Features; selecting a Feature narrows Stories. The most specific selection is linked as the new ticket's parent.
- Backend: new `getPotentialParents()` in `src/lib/devops.ts` returns Epic / Feature / User Story / Product Backlog Item / Requirement work items in non-terminal states, with each item's `parentId` derived from `Hierarchy-Reverse` relations so the UI can cascade-filter.
- New API route `GET /api/devops/projects/[project]/parent-candidates`.
- `createTicketWithAssignee` accepts an optional `parentId` and appends a `System.LinkTypes.Hierarchy-Reverse` relation to the create request — same retry path on rule-validation errors.
- `POST /api/devops/tickets` validates `parentId` (positive integer) and forwards it.
- Smaller dialog (`NewTicketModal`, used by Monthly Checkpoint) gets a single searchable parent picker via the same endpoint.

<img width="1908" height="912" alt="image" src="https://github.com/user-attachments/assets/21f4fcbd-78c9-482a-9347-6b3928b9a869" />

Closes #340

## Test plan
- [x] Open **+Add** in the sidebar, pick a project, confirm three new selects appear under Iteration: Epic, Feature, User Story
- [x] Pick an Epic — Feature dropdown narrows to children of that Epic; Story dropdown narrows to stories rolling up to that Epic
- [x] Pick a Feature — Story dropdown narrows to children of that Feature
- [x] Submit with no parent selections → ticket is created with no parent link
- [x] Submit with only an Epic selected → Epic becomes the parent in DevOps
- [x] Submit with Epic + Feature → Feature becomes the parent
- [x] Submit with Epic + Feature + Story → Story becomes the parent
- [x] Open ticket in DevOps and confirm the parent link is visible
- [x] Verify on Scrum-template projects that "Product Backlog Item" entries appear under the Story tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)