### PR TITLE
perf: cut redundant API calls and add caches for /kanban load

### DIFF
--- a/src/app/api/devops/standup/route.ts
+++ b/src/app/api/devops/standup/route.ts
@@ -29,8 +29,12 @@ async function fetchStateCategories(
   organization: string
 ): Promise<Record<string, string>> {
   const cached = stateCategoryCacheByOrg.get(organization);
-  if (cached && Date.now() - cached.timestamp < STATE_CACHE_TTL_MS) {
-    return cached.categories;
+  if (cached) {
+    if (Date.now() - cached.timestamp < STATE_CACHE_TTL_MS) {
+      return cached.categories;
+    }
+    // Expired — evict so the map doesn't accumulate stale per-org entries forever.
+    stateCategoryCacheByOrg.delete(organization);
   }
 
   const inFlight = stateCategoryInFlight.get(organization);

--- a/src/app/api/devops/standup/route.ts
+++ b/src/app/api/devops/standup/route.ts
@@ -11,42 +11,56 @@ import type {
   TicketPriority,
 } from '@/types';
 
-// TTL cache for state categories
-let stateCategoryCacheData: {
-  categories: Record<string, string>;
-  timestamp: number;
-  org: string;
-} | null = null;
-const STATE_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+// Per-org TTL cache + in-flight dedup for state categories.
+// State definitions virtually never change in production, so we cache
+// aggressively (1 hour). The dedup map prevents thundering-herd refetches
+// when many requests arrive simultaneously after a cache expiry.
+const stateCategoryCacheByOrg: Map<
+  string,
+  { categories: Record<string, string>; timestamp: number }
+> = new Map();
+const stateCategoryInFlight: Map<string, Promise<Record<string, string>>> = new Map();
+const STATE_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
 // Fetch work item states and build state-to-category mapping
 async function fetchStateCategories(
+  devopsService: AzureDevOpsService,
   accessToken: string,
   organization: string
 ): Promise<Record<string, string>> {
-  // Return cached data if fresh and same org
-  if (
-    stateCategoryCacheData &&
-    stateCategoryCacheData.org === organization &&
-    Date.now() - stateCategoryCacheData.timestamp < STATE_CACHE_TTL_MS
-  ) {
-    return stateCategoryCacheData.categories;
+  const cached = stateCategoryCacheByOrg.get(organization);
+  if (cached && Date.now() - cached.timestamp < STATE_CACHE_TTL_MS) {
+    return cached.categories;
   }
 
-  const projectsResponse = await fetch(
-    `https://dev.azure.com/${organization}/_apis/projects?api-version=7.0`,
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'application/json',
-      },
+  const inFlight = stateCategoryInFlight.get(organization);
+  if (inFlight) return inFlight;
+
+  const promise = doFetchStateCategories(devopsService, accessToken, organization);
+  stateCategoryInFlight.set(organization, promise);
+  try {
+    const categories = await promise;
+    if (Object.keys(categories).length > 0) {
+      stateCategoryCacheByOrg.set(organization, { categories, timestamp: Date.now() });
     }
-  );
+    return categories;
+  } finally {
+    stateCategoryInFlight.delete(organization);
+  }
+}
 
-  if (!projectsResponse.ok) return {};
-
-  const projectsData = await projectsResponse.json();
-  const projects: { name: string }[] = projectsData.value || [];
+async function doFetchStateCategories(
+  devopsService: AzureDevOpsService,
+  accessToken: string,
+  organization: string
+): Promise<Record<string, string>> {
+  // Reuse the cached project list rather than re-fetching independently
+  let projects: { name: string }[] = [];
+  try {
+    projects = await devopsService.getProjects();
+  } catch {
+    return {};
+  }
   if (projects.length === 0) return {};
 
   const stateCategories: Record<string, string> = {};
@@ -105,12 +119,6 @@ async function fetchStateCategories(
       }
     }
   }
-
-  stateCategoryCacheData = {
-    categories: stateCategories,
-    timestamp: Date.now(),
-    org: organization,
-  };
 
   return stateCategories;
 }
@@ -180,19 +188,20 @@ export async function GET(request: NextRequest) {
     const currentSprintOnly = searchParams.get('currentSprintOnly') === 'true';
     const targetDate = dateParam ? new Date(dateParam + 'T12:00:00Z') : new Date();
 
-    // Step 1: Fetch state categories dynamically from DevOps
-    const stateCategories = await fetchStateCategories(session.accessToken, organization);
+    // Step 1: Fetch state categories dynamically from DevOps (cached + deduped)
+    const devopsService = new AzureDevOpsService(session.accessToken, organization);
+    const stateCategories = await fetchStateCategories(
+      devopsService,
+      session.accessToken,
+      organization
+    );
 
     if (Object.keys(stateCategories).length === 0) {
       return NextResponse.json({ error: 'Failed to fetch state categories' }, { status: 500 });
     }
 
     // Step 2: Fetch work items using dynamic state lists
-    const devopsService = new AzureDevOpsService(session.accessToken, organization);
-    const { doneItems, activeItems } = await devopsService.getStandupData(
-      targetDate,
-      stateCategories
-    );
+    const { items } = await devopsService.getStandupData(targetDate, stateCategories);
 
     // Step 2b: If currentSprintOnly, fetch current iterations and filter
     let currentIterations: Map<string, string> | null = null;
@@ -210,8 +219,7 @@ export async function GET(request: NextRequest) {
       return iterationPath.startsWith(currentIteration);
     }
 
-    const filteredDoneItems = doneItems.filter(isInCurrentSprint);
-    const filteredActiveItems = activeItems.filter(isInCurrentSprint);
+    const filteredItems = items.filter(isInCurrentSprint);
 
     // Step 3: Define the 6 display columns and map DevOps states to them
     // Items in states not matching a column are bucketed by their category.
@@ -256,15 +264,8 @@ export async function GET(request: NextRequest) {
       return projectMap.get(name)!;
     };
 
-    // Place done items into their resolved column
-    for (const wi of filteredDoneItems) {
-      const colMap = ensureProject(wi.fields['System.TeamProject']);
-      const column = resolveColumn(wi.fields['System.State']);
-      colMap.get(column)!.push(mapWorkItemToStandupItem(wi, organization, stateCategories));
-    }
-
-    // Place active items into their resolved column
-    for (const wi of filteredActiveItems) {
+    // Place items into their resolved column
+    for (const wi of filteredItems) {
       const colMap = ensureProject(wi.fields['System.TeamProject']);
       const column = resolveColumn(wi.fields['System.State']);
       colMap.get(column)!.push(mapWorkItemToStandupItem(wi, organization, stateCategories));

--- a/src/app/kanban/page.tsx
+++ b/src/app/kanban/page.tsx
@@ -13,6 +13,17 @@ import type { StandupData, StandupColumn, StandupWorkItem } from '@/types';
 
 type GroupBy = 'project' | 'person';
 
+// Module-level cache: navigating away and back to /kanban returns instantly
+// from the previous fetch (within TTL) instead of re-hitting the API. The
+// in-flight map dedupes concurrent calls (e.g. mount + auto-refresh tick).
+const STANDUP_CACHE_TTL_MS = 30 * 1000;
+const standupCache: Map<string, { data: StandupData; timestamp: number }> = new Map();
+const standupInFlight: Map<string, Promise<StandupData>> = new Map();
+
+function cacheKey(currentSprintOnly: boolean): string {
+  return currentSprintOnly ? 'sprint' : 'all';
+}
+
 /** Build /kanban URL with the given params */
 function buildKanbanUrl(groupBy: GroupBy, sprint: boolean): string {
   const params = new URLSearchParams();
@@ -96,10 +107,24 @@ function StandupPageContent() {
   autoRefreshRef.current = autoRefresh;
 
   const fetchStandupData = useCallback(
-    async (isAutoRefresh = false) => {
+    async (isAutoRefresh = false, forceRefresh = false) => {
       if (!session?.accessToken || !hasOrganization) {
         setLoading(false);
         return;
+      }
+
+      const key = cacheKey(currentSprintOnly);
+
+      // Serve fresh cached data instantly (back-navigation case)
+      if (!forceRefresh) {
+        const cached = standupCache.get(key);
+        if (cached && Date.now() - cached.timestamp < STANDUP_CACHE_TTL_MS) {
+          setStandupData(cached.data);
+          setLoading(false);
+          setRefreshing(false);
+          setError(null);
+          return;
+        }
       }
 
       if (isAutoRefresh) {
@@ -110,17 +135,32 @@ function StandupPageContent() {
       setError(null);
 
       try {
-        const params = new URLSearchParams();
-        if (currentSprintOnly) {
-          params.set('currentSprintOnly', 'true');
+        // Dedupe concurrent requests for the same cache key
+        let promise = forceRefresh ? undefined : standupInFlight.get(key);
+        if (!promise) {
+          promise = (async () => {
+            const params = new URLSearchParams();
+            if (currentSprintOnly) {
+              params.set('currentSprintOnly', 'true');
+            }
+            const queryString = params.toString();
+            const url = `/api/devops/standup${queryString ? `?${queryString}` : ''}`;
+            const response = await devOpsGet(url);
+            if (!response.ok) {
+              throw new Error('Failed to fetch standup data');
+            }
+            return (await response.json()) as StandupData;
+          })();
+          standupInFlight.set(key, promise);
         }
-        const queryString = params.toString();
-        const url = `/api/devops/standup${queryString ? `?${queryString}` : ''}`;
-        const response = await devOpsGet(url);
-        if (!response.ok) {
-          throw new Error('Failed to fetch standup data');
+
+        let data: StandupData;
+        try {
+          data = await promise;
+        } finally {
+          standupInFlight.delete(key);
         }
-        const data: StandupData = await response.json();
+        standupCache.set(key, { data, timestamp: Date.now() });
         setStandupData(data);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load standup data');
@@ -142,7 +182,7 @@ function StandupPageContent() {
     if (!autoRefresh) return;
     const interval = setInterval(() => {
       if (autoRefreshRef.current) {
-        fetchStandupData(true);
+        fetchStandupData(true, true);
       }
     }, 30000);
     return () => clearInterval(interval);
@@ -158,7 +198,7 @@ function StandupPageContent() {
         throw new Error('Failed to update state');
       }
 
-      fetchStandupData(true);
+      fetchStandupData(true, true);
     },
     [fetchStandupData, devOpsPatch]
   );
@@ -274,7 +314,7 @@ function StandupPageContent() {
 
               {/* Manual refresh */}
               <button
-                onClick={() => fetchStandupData(true)}
+                onClick={() => fetchStandupData(true, true)}
                 disabled={refreshing}
                 className="rounded-md p-2 transition-colors hover:bg-white/10"
                 style={{ color: refreshing ? 'var(--text-muted)' : 'var(--text-secondary)' }}

--- a/src/app/kanban/page.tsx
+++ b/src/app/kanban/page.tsx
@@ -20,8 +20,8 @@ const STANDUP_CACHE_TTL_MS = 30 * 1000;
 const standupCache: Map<string, { data: StandupData; timestamp: number }> = new Map();
 const standupInFlight: Map<string, Promise<StandupData>> = new Map();
 
-function cacheKey(currentSprintOnly: boolean): string {
-  return currentSprintOnly ? 'sprint' : 'all';
+function cacheKey(organization: string, currentSprintOnly: boolean): string {
+  return `${organization}::${currentSprintOnly ? 'sprint' : 'all'}`;
 }
 
 /** Build /kanban URL with the given params */
@@ -92,7 +92,12 @@ function StandupPageContent() {
   const { data: session, status } = useSession();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { get: devOpsGet, patch: devOpsPatch, hasOrganization } = useDevOpsApi();
+  const {
+    get: devOpsGet,
+    patch: devOpsPatch,
+    hasOrganization,
+    selectedOrganization,
+  } = useDevOpsApi();
 
   // Derive from URL — single source of truth
   const groupBy: GroupBy = (searchParams.get('groupBy') as GroupBy) || 'project';
@@ -108,12 +113,12 @@ function StandupPageContent() {
 
   const fetchStandupData = useCallback(
     async (isAutoRefresh = false, forceRefresh = false) => {
-      if (!session?.accessToken || !hasOrganization) {
+      if (!session?.accessToken || !hasOrganization || !selectedOrganization?.accountName) {
         setLoading(false);
         return;
       }
 
-      const key = cacheKey(currentSprintOnly);
+      const key = cacheKey(selectedOrganization.accountName, currentSprintOnly);
 
       // Serve fresh cached data instantly (back-navigation case)
       if (!forceRefresh) {
@@ -169,7 +174,13 @@ function StandupPageContent() {
         setRefreshing(false);
       }
     },
-    [session?.accessToken, hasOrganization, devOpsGet, currentSprintOnly]
+    [
+      session?.accessToken,
+      hasOrganization,
+      selectedOrganization?.accountName,
+      devOpsGet,
+      currentSprintOnly,
+    ]
   );
 
   useEffect(() => {

--- a/src/lib/devops.ts
+++ b/src/lib/devops.ts
@@ -85,6 +85,12 @@ let stateCategoryCache: Record<string, string> = {};
 const projectListCache: Map<string, { data: DevOpsProject[]; timestamp: number }> = new Map();
 const PROJECT_CACHE_TTL_MS = 30 * 1000; // 30 seconds
 
+// Cache for current iterations per organization
+const currentIterationsCache: Map<string, { data: Map<string, string>; timestamp: number }> =
+  new Map();
+const currentIterationsInFlight: Map<string, Promise<Map<string, string>>> = new Map();
+const CURRENT_ITERATIONS_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
 // Set the state category cache (called from API routes after fetching states)
 export function setStateCategoryCache(stateCategories: Record<string, string>) {
   stateCategoryCache = stateCategories;
@@ -2317,8 +2323,27 @@ export class AzureDevOpsService {
     };
   }
 
-  // Fetch current iteration path for each project
+  // Fetch current iteration path for each project (cached per-org)
   async getCurrentIterations(): Promise<Map<string, string>> {
+    const cached = currentIterationsCache.get(this.organization);
+    if (cached && Date.now() - cached.timestamp < CURRENT_ITERATIONS_TTL_MS) {
+      return cached.data;
+    }
+    const inFlight = currentIterationsInFlight.get(this.organization);
+    if (inFlight) return inFlight;
+
+    const promise = this.fetchCurrentIterations();
+    currentIterationsInFlight.set(this.organization, promise);
+    try {
+      const data = await promise;
+      currentIterationsCache.set(this.organization, { data, timestamp: Date.now() });
+      return data;
+    } finally {
+      currentIterationsInFlight.delete(this.organization);
+    }
+  }
+
+  private async fetchCurrentIterations(): Promise<Map<string, string>> {
     const result = new Map<string, string>();
 
     try {
@@ -2380,7 +2405,7 @@ export class AzureDevOpsService {
   async getStandupData(
     targetDate: Date,
     stateCategories: Record<string, string>
-  ): Promise<{ doneItems: DevOpsWorkItem[]; activeItems: DevOpsWorkItem[] }> {
+  ): Promise<{ items: DevOpsWorkItem[] }> {
     const dateStr = targetDate.toISOString().split('T')[0];
 
     // "Yesterday" relative to the target date
@@ -2400,7 +2425,7 @@ export class AzureDevOpsService {
     }
 
     if (doneStates.length === 0 || activeStates.length === 0) {
-      return { doneItems: [], activeItems: [] };
+      return { items: [] };
     }
 
     const escapeState = (s: string) => s.replace(/'/g, "''");
@@ -2477,15 +2502,13 @@ export class AzureDevOpsService {
     const doneData = await doneResponse.json();
     const activeData = await activeResponse.json();
 
-    // Batch-fetch work item details
-    const doneItems = await this.fetchWorkItemBatch(
-      doneData.workItems?.map((wi: { id: number }) => wi.id) || []
-    );
-    const activeItems = await this.fetchWorkItemBatch(
-      activeData.workItems?.map((wi: { id: number }) => wi.id) || []
-    );
+    // Combine IDs and batch-fetch in one pass — saves a round-trip when the
+    // total fits in a single 200-item batch (the common case).
+    const doneIds: number[] = doneData.workItems?.map((wi: { id: number }) => wi.id) || [];
+    const activeIds: number[] = activeData.workItems?.map((wi: { id: number }) => wi.id) || [];
+    const items = await this.fetchWorkItemBatch([...doneIds, ...activeIds]);
 
-    return { doneItems, activeItems };
+    return { items };
   }
 
   // Fetch work item details in batches of 200

--- a/src/lib/devops.ts
+++ b/src/lib/devops.ts
@@ -2326,8 +2326,12 @@ export class AzureDevOpsService {
   // Fetch current iteration path for each project (cached per-org)
   async getCurrentIterations(): Promise<Map<string, string>> {
     const cached = currentIterationsCache.get(this.organization);
-    if (cached && Date.now() - cached.timestamp < CURRENT_ITERATIONS_TTL_MS) {
-      return cached.data;
+    if (cached) {
+      if (Date.now() - cached.timestamp < CURRENT_ITERATIONS_TTL_MS) {
+        return cached.data;
+      }
+      // Expired — evict so the map doesn't accumulate stale per-org entries forever.
+      currentIterationsCache.delete(this.organization);
     }
     const inFlight = currentIterationsInFlight.get(this.organization);
     if (inFlight) return inFlight;


### PR DESCRIPTION
## Summary

- Bump state-categories TTL from 5 min to **1 hour** and add per-org **in-flight dedup**; reuse `getProjects()` (already cached) instead of refetching the project list independently.
- Cache `getCurrentIterations` for **5 min per-org** with in-flight dedup, removing 2*N team/iteration calls on warm cache when the Sprint filter is on.
- Combine the done + active work-item batch fetches into a **single batch call** (saves a round-trip when the total fits in 200 items, the common case).
- Add a **30s module-level client cache** keyed by sprint filter so back-navigation to `/kanban` serves instantly. Manual refresh, auto-refresh tick, and state-change patches all bypass the cache.
- Client-side **request dedup** for concurrent fetches against the same key.

Fixes #352

## Test plan

- [x] Cold load: open `/kanban` after a server restart — confirm board renders correctly with all expected projects and work items.
- [x] Back-navigation: navigate away (e.g. to `/tickets`) and back to `/kanban` within 30s — confirm the page renders instantly without a network call to `/api/devops/standup`.
- [x] Group By: toggle Project ↔ Person — confirm regrouping is instant and triggers no network call.
- [x] Sprint filter: toggle Current Sprint on/off — confirm the request fires and the result is correct (filtered to current iteration paths).
- [x] Manual refresh: click the refresh icon — confirm it always re-hits the API even within the cache window.
- [x] Auto-refresh: enable Auto-refresh — confirm the 30s tick re-hits the API and updates the board.
- [x] State change: drag/drop or click to change a card state — confirm the API patch fires and the board re-fetches with the new state.
- [x] DevTools Network tab: confirm a warm cold cache run shows substantially fewer Azure DevOps calls than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
