### PR TITLE
fix: keep recently-closed items visible in Kanban Closed column

### DIFF
--- a/src/components/standup/KanbanGroupSection.tsx
+++ b/src/components/standup/KanbanGroupSection.tsx
@@ -16,10 +16,14 @@ import {
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { useDroppable } from '@dnd-kit/core';
 import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
-import { ChevronDown, ChevronRight } from 'lucide-react';
+import { ChevronDown, ChevronRight, Info } from 'lucide-react';
 import StandupKanbanCard from './StandupKanbanCard';
 import { getColumnIcon, getColumnColor } from './columnConfig';
 import type { StandupColumn, StandupWorkItem } from '@/types';
+
+// Done-category columns only show items changed in the last 7 days; this hint
+// explains the cutoff so users don't think older closed items have vanished.
+const DONE_WINDOW_HINT = 'Showing items closed in the last 7 days';
 
 /** Simple droppable column for the standup kanban */
 function DroppableColumn({
@@ -35,6 +39,7 @@ function DroppableColumn({
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: name });
   const color = getColumnColor(name, category);
+  const isDoneColumn = category === 'Resolved' || category === 'Completed';
 
   return (
     <div className="kanban-column">
@@ -42,6 +47,16 @@ function DroppableColumn({
         <div className="flex items-center gap-2">
           <span style={{ color }}>{getColumnIcon(name, category)}</span>
           <h3 className="text-sm font-semibold text-[var(--text-primary)]">{name}</h3>
+          {isDoneColumn && (
+            <span
+              title={DONE_WINDOW_HINT}
+              aria-label={DONE_WINDOW_HINT}
+              className="cursor-help"
+              style={{ color: 'var(--text-muted)' }}
+            >
+              <Info size={12} />
+            </span>
+          )}
         </div>
         <span className="rounded-full bg-[var(--surface-hover)] px-2 py-0.5 text-xs text-[var(--text-muted)]">
           {items.length}

--- a/src/components/standup/KanbanGroupSection.tsx
+++ b/src/components/standup/KanbanGroupSection.tsx
@@ -22,8 +22,8 @@ import { getColumnIcon, getColumnColor } from './columnConfig';
 import type { StandupColumn, StandupWorkItem } from '@/types';
 
 // Done-category columns only show items changed in the last 7 days; this hint
-// explains the cutoff so users don't think older closed items have vanished.
-const DONE_WINDOW_HINT = 'Showing items closed in the last 7 days';
+// explains the cutoff so users don't think older items have vanished.
+const DONE_WINDOW_HINT = 'Showing items resolved or closed in the last 7 days';
 
 /** Simple droppable column for the standup kanban */
 function DroppableColumn({
@@ -48,14 +48,15 @@ function DroppableColumn({
           <span style={{ color }}>{getColumnIcon(name, category)}</span>
           <h3 className="text-sm font-semibold text-[var(--text-primary)]">{name}</h3>
           {isDoneColumn && (
-            <span
+            <button
+              type="button"
               title={DONE_WINDOW_HINT}
               aria-label={DONE_WINDOW_HINT}
               className="cursor-help"
               style={{ color: 'var(--text-muted)' }}
             >
               <Info size={12} />
-            </span>
+            </button>
           )}
         </div>
         <span className="rounded-full bg-[var(--surface-hover)] px-2 py-0.5 text-xs text-[var(--text-muted)]">

--- a/src/lib/devops.ts
+++ b/src/lib/devops.ts
@@ -2414,9 +2414,14 @@ export class AzureDevOpsService {
     // This matches the "recently-solved" view elsewhere in the app and ensures
     // items moved to a done state today still appear in the Closed column on
     // the Kanban board (issue #317).
+    // The upper bound (< nextDay) anchors the window to targetDate so historical
+    // ?date=... requests don't pick up items changed after that date.
     const sevenDaysAgo = new Date(targetDate);
     sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
     const sevenDaysAgoStr = sevenDaysAgo.toISOString().split('T')[0];
+    const nextDay = new Date(targetDate);
+    nextDay.setDate(nextDay.getDate() + 1);
+    const nextDayStr = nextDay.toISOString().split('T')[0];
 
     // Build state lists dynamically from categories
     const doneStates: string[] = [];
@@ -2462,6 +2467,7 @@ export class AzureDevOpsService {
         WHERE [System.State] IN (${doneStatesList})
           AND [System.WorkItemType] IN (${allowedTypesList})
           AND [System.ChangedDate] >= '${sevenDaysAgoStr}'
+          AND [System.ChangedDate] < '${nextDayStr}'
         ORDER BY [System.TeamProject] ASC, [System.ChangedDate] DESC
       `,
     };

--- a/src/lib/devops.ts
+++ b/src/lib/devops.ts
@@ -2404,18 +2404,19 @@ export class AzureDevOpsService {
     return result;
   }
 
-  // Daily Standup: fetch work items across all projects for a given date
-  // Uses org-level WIQL queries (no project scope) for performance
+  // Kanban / Standup: fetch work items across all projects for a given date.
+  // Uses org-level WIQL queries (no project scope) for performance.
   async getStandupData(
     targetDate: Date,
     stateCategories: Record<string, string>
   ): Promise<{ items: DevOpsWorkItem[] }> {
-    const dateStr = targetDate.toISOString().split('T')[0];
-
-    // "Yesterday" relative to the target date
-    const yesterday = new Date(targetDate);
-    yesterday.setDate(yesterday.getDate() - 1);
-    const yesterdayStr = yesterday.toISOString().split('T')[0];
+    // Recently-done window: 7 days ending on the target date (inclusive).
+    // This matches the "recently-solved" view elsewhere in the app and ensures
+    // items moved to a done state today still appear in the Closed column on
+    // the Kanban board (issue #317).
+    const sevenDaysAgo = new Date(targetDate);
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+    const sevenDaysAgoStr = sevenDaysAgo.toISOString().split('T')[0];
 
     // Build state lists dynamically from categories
     const doneStates: string[] = [];
@@ -2453,15 +2454,14 @@ export class AzureDevOpsService {
       'Microsoft.VSTS.Common.Priority',
     ].join(', ');
 
-    // Query 1: Items moved to done states on the previous day
+    // Query 1: Items currently in a done state, moved there in the last 7 days
     const doneQuery = {
       query: `
         SELECT ${fields}
         FROM WorkItems
         WHERE [System.State] IN (${doneStatesList})
           AND [System.WorkItemType] IN (${allowedTypesList})
-          AND [System.ChangedDate] >= '${yesterdayStr}'
-          AND [System.ChangedDate] < '${dateStr}'
+          AND [System.ChangedDate] >= '${sevenDaysAgoStr}'
         ORDER BY [System.TeamProject] ASC, [System.ChangedDate] DESC
       `,
     };

--- a/src/lib/devops.ts
+++ b/src/lib/devops.ts
@@ -2416,9 +2416,12 @@ export class AzureDevOpsService {
     // the Kanban board (issue #317).
     // The upper bound (< nextDay) anchors the window to targetDate so historical
     // ?date=... requests don't pick up items changed after that date.
-    const sevenDaysAgo = new Date(targetDate);
-    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
-    const sevenDaysAgoStr = sevenDaysAgo.toISOString().split('T')[0];
+    // Subtract 6 (not 7) so [windowStart, nextDay) covers exactly 7 calendar
+    // days inclusive of the target day — otherwise the date-only truncation
+    // would give us 8 days.
+    const windowStart = new Date(targetDate);
+    windowStart.setDate(windowStart.getDate() - 6);
+    const sevenDaysAgoStr = windowStart.toISOString().split('T')[0];
     const nextDay = new Date(targetDate);
     nextDay.setDate(nextDay.getDate() + 1);
     const nextDayStr = nextDay.toISOString().split('T')[0];


### PR DESCRIPTION
## Summary
- The standup WIQL "done" query in `getStandupData` bounded `ChangedDate` to **yesterday only** (`>= yesterday AND < today`). Items moved to a done state *today* failed that upper bound, were also excluded from the active query, and disappeared from the Kanban entirely.
- Replaced the bounded range with a **7-day rolling window** for items currently in a done state. Matches the "recently-solved" semantics used elsewhere in the app.
<img width="1625" height="846" alt="image" src="https://github.com/user-attachments/assets/d30fc78f-654c-4146-ae96-827614a65688" />


Fixes #317

## Test plan
- [x] Open `/kanban`, drag any item to **Closed** (or click to change state)
- [x] After the auto refresh, confirm the item appears in the **Closed** column (not just dropped from view)
- [x] Items closed in the last 7 days remain visible in the Closed column
- [x] Items closed > 7 days ago are not shown (column doesn't grow forever)
- [x] Active columns still behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)