### PR TITLE
fix: keep org switcher visible when only one organization

### DIFF
--- a/src/components/layout/OrganizationSwitcher.tsx
+++ b/src/components/layout/OrganizationSwitcher.tsx
@@ -32,7 +32,7 @@ export default function OrganizationSwitcher() {
     };
   }, []);
 
-  // Don't render if only one organization or still loading with no orgs
+  // Loader while we don't have any orgs yet
   if (isLoading && organizations.length === 0) {
     return (
       <div className="flex items-center gap-2 rounded-md px-3 py-1.5">
@@ -41,9 +41,27 @@ export default function OrganizationSwitcher() {
     );
   }
 
-  // Hide if only one organization
-  if (organizations.length <= 1) {
+  // Nothing to show if we have no orgs at all
+  if (organizations.length === 0) {
     return null;
+  }
+
+  // Single-org case: show a passive label so the user always knows which
+  // organization they're in (issue #367) — no dropdown chevron / interaction.
+  const isMultiOrg = organizations.length > 1;
+  if (!isMultiOrg) {
+    return (
+      <div
+        className="flex items-center gap-2 rounded-md px-3 py-1.5"
+        style={{ color: 'var(--text-primary)' }}
+        aria-label="Current organization"
+      >
+        <Building2 size={16} style={{ color: 'var(--primary)' }} />
+        <span className="max-w-[150px] truncate text-sm font-medium">
+          {selectedOrganization?.accountName || organizations[0].accountName}
+        </span>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- `OrganizationSwitcher` previously returned `null` whenever the user had access to a single Azure DevOps organization, so there was no indication of which org was active.
- Now renders a passive label (Building2 icon + org name, no chevron / dropdown) when there's exactly one org. Multi-org behaviour is unchanged — full clickable switcher with dropdown.
<img width="1911" height="918" alt="image" src="https://github.com/user-attachments/assets/dd2a29ae-170c-4c54-afe1-ca495605b514" />


Fixes #367

## Test plan
- [x] Sign in with an account that has access to only one DevOps organization → confirm the org name is visible in the top-right header (icon + name, no chevron, not clickable)
- [x] Sign in with an account that has access to multiple organizations → confirm the dropdown still works (chevron rotates, list shows all orgs, switching works)
- [x] Reload during fetch → loader is shown briefly, then the appropriate UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)