### PR TITLE
feat: open work item in dialog from Kanban board

### DIFF
--- a/src/app/kanban/page.tsx
+++ b/src/app/kanban/page.tsx
@@ -117,6 +117,9 @@ function StandupPageContent() {
   // opens it in a dialog rather than navigating to the full page (#368).
   const [selectedTicket, setSelectedTicket] = useState<Ticket | null>(null);
   const [isLoadingTicket, setIsLoadingTicket] = useState(false);
+  // Monotonic request id so a slow first click can't overwrite the dialog
+  // when a second card is clicked before the first response arrives.
+  const ticketFetchSeqRef = useRef(0);
 
   const fetchStandupData = useCallback(
     async (isAutoRefresh = false, forceRefresh = false) => {
@@ -206,11 +209,13 @@ function StandupPageContent() {
     return () => clearInterval(interval);
   }, [autoRefresh, fetchStandupData]);
 
+  // Generic state-change. Pass `project` when known to avoid an
+  // expensive cross-project scan on the server.
   const handleStateChange = useCallback(
-    async (itemId: number, targetState: string) => {
-      const response = await devOpsPatch(`/api/devops/tickets/${itemId}/state`, {
-        state: targetState,
-      });
+    async (itemId: number, targetState: string, project?: string) => {
+      const body: Record<string, unknown> = { state: targetState };
+      if (project) body.project = project;
+      const response = await devOpsPatch(`/api/devops/tickets/${itemId}/state`, body);
 
       if (!response.ok) {
         throw new Error('Failed to update state');
@@ -221,27 +226,35 @@ function StandupPageContent() {
     [fetchStandupData, devOpsPatch]
   );
 
-  // Fetch the full Ticket on card click and open the detail dialog
+  // Fetch the full Ticket on card click and open the detail dialog.
+  // Uses a monotonic seq id so out-of-order responses from rapid clicks
+  // can't overwrite the dialog with a stale ticket.
   const handleItemClick = useCallback(
     async (item: StandupWorkItem) => {
+      const mySeq = ++ticketFetchSeqRef.current;
       setIsLoadingTicket(true);
       try {
         const response = await devOpsGet(`/api/devops/tickets/${item.id}`);
+        if (mySeq !== ticketFetchSeqRef.current) return; // a newer click superseded us
         if (!response.ok) {
           throw new Error('Failed to fetch ticket');
         }
         const data = (await response.json()) as {
           ticket: Ticket & { createdAt: string; updatedAt: string };
         };
+        if (mySeq !== ticketFetchSeqRef.current) return;
         setSelectedTicket({
           ...data.ticket,
           createdAt: new Date(data.ticket.createdAt),
           updatedAt: new Date(data.ticket.updatedAt),
         });
       } catch (err) {
+        if (mySeq !== ticketFetchSeqRef.current) return;
         console.error('Failed to load ticket for dialog:', err);
       } finally {
-        setIsLoadingTicket(false);
+        if (mySeq === ticketFetchSeqRef.current) {
+          setIsLoadingTicket(false);
+        }
       }
     },
     [devOpsGet]
@@ -249,12 +262,15 @@ function StandupPageContent() {
 
   // Dialog state-change: reuse existing kanban state-change logic, then
   // mirror the new state on selectedTicket so the dialog UI updates.
+  // Pass project so the server doesn't have to scan every project to find
+  // the work item.
   const handleDialogStateChange = useCallback(
     async (workItemId: number, state: string) => {
-      await handleStateChange(workItemId, state);
+      const project = selectedTicket?.id === workItemId ? selectedTicket.project : undefined;
+      await handleStateChange(workItemId, state, project);
       setSelectedTicket((prev) => (prev ? { ...prev, devOpsState: state } : null));
     },
-    [handleStateChange]
+    [handleStateChange, selectedTicket]
   );
 
   // Generic PATCH helper used by the dialog's assignee/priority/tags/update handlers.

--- a/src/app/kanban/page.tsx
+++ b/src/app/kanban/page.tsx
@@ -8,8 +8,10 @@ import { RefreshCw, FolderOpen, User } from 'lucide-react';
 import { MainLayout } from '@/components/layout';
 import { LoadingSpinner } from '@/components/common';
 import { StandupSummaryCards, KanbanGroupSection } from '@/components/standup';
+import WorkItemDetailDialog from '@/components/tickets/WorkItemDetailDialog';
 import { useDevOpsApi } from '@/hooks';
-import type { StandupData, StandupColumn, StandupWorkItem } from '@/types';
+import { ticketToWorkItem } from '@/lib/devops';
+import type { StandupData, StandupColumn, StandupWorkItem, Ticket } from '@/types';
 
 type GroupBy = 'project' | 'person';
 
@@ -110,6 +112,11 @@ function StandupPageContent() {
   const [autoRefresh, setAutoRefresh] = useState(false);
   const autoRefreshRef = useRef(autoRefresh);
   autoRefreshRef.current = autoRefresh;
+
+  // Detail dialog state — clicking a card fetches the full ticket and
+  // opens it in a dialog rather than navigating to the full page (#368).
+  const [selectedTicket, setSelectedTicket] = useState<Ticket | null>(null);
+  const [isLoadingTicket, setIsLoadingTicket] = useState(false);
 
   const fetchStandupData = useCallback(
     async (isAutoRefresh = false, forceRefresh = false) => {
@@ -212,6 +219,141 @@ function StandupPageContent() {
       fetchStandupData(true, true);
     },
     [fetchStandupData, devOpsPatch]
+  );
+
+  // Fetch the full Ticket on card click and open the detail dialog
+  const handleItemClick = useCallback(
+    async (item: StandupWorkItem) => {
+      setIsLoadingTicket(true);
+      try {
+        const response = await devOpsGet(`/api/devops/tickets/${item.id}`);
+        if (!response.ok) {
+          throw new Error('Failed to fetch ticket');
+        }
+        const data = (await response.json()) as {
+          ticket: Ticket & { createdAt: string; updatedAt: string };
+        };
+        setSelectedTicket({
+          ...data.ticket,
+          createdAt: new Date(data.ticket.createdAt),
+          updatedAt: new Date(data.ticket.updatedAt),
+        });
+      } catch (err) {
+        console.error('Failed to load ticket for dialog:', err);
+      } finally {
+        setIsLoadingTicket(false);
+      }
+    },
+    [devOpsGet]
+  );
+
+  // Dialog state-change: reuse existing kanban state-change logic, then
+  // mirror the new state on selectedTicket so the dialog UI updates.
+  const handleDialogStateChange = useCallback(
+    async (workItemId: number, state: string) => {
+      await handleStateChange(workItemId, state);
+      setSelectedTicket((prev) => (prev ? { ...prev, devOpsState: state } : null));
+    },
+    [handleStateChange]
+  );
+
+  // Generic PATCH helper used by the dialog's assignee/priority/tags/update handlers.
+  // The standup data refresh happens after the patch so the board stays in sync.
+  const patchTicket = useCallback(
+    async (workItemId: number, body: Record<string, unknown>) => {
+      const response = await devOpsPatch(`/api/devops/tickets/${workItemId}`, body);
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed to update work item');
+      }
+      const data = await response.json().catch(() => ({}));
+      const updated = data.ticket as Ticket | undefined;
+      if (updated) {
+        setSelectedTicket((prev) =>
+          prev && prev.id === updated.id
+            ? {
+                ...updated,
+                createdAt: new Date(updated.createdAt),
+                updatedAt: new Date(updated.updatedAt),
+              }
+            : prev
+        );
+      }
+      fetchStandupData(true, true);
+      return updated;
+    },
+    [devOpsPatch, fetchStandupData]
+  );
+
+  const handleDialogAssigneeChange = useCallback(
+    async (workItemId: number, assigneeId: string | null) => {
+      const project = selectedTicket?.id === workItemId ? selectedTicket.project : undefined;
+      await patchTicket(workItemId, { assignee: assigneeId, project });
+    },
+    [patchTicket, selectedTicket]
+  );
+
+  const handleDialogPriorityChange = useCallback(
+    async (workItemId: number, priority: number) => {
+      const project = selectedTicket?.id === workItemId ? selectedTicket.project : undefined;
+      await patchTicket(workItemId, { priority, project });
+    },
+    [patchTicket, selectedTicket]
+  );
+
+  const handleDialogTagsChange = useCallback(
+    async (workItemId: number, tags: string[]) => {
+      const project = selectedTicket?.id === workItemId ? selectedTicket.project : undefined;
+      await patchTicket(workItemId, { tags, project });
+      // Optimistic update for the tags field if the PATCH didn't return the ticket
+      setSelectedTicket((prev) => (prev && prev.id === workItemId ? { ...prev, tags } : prev));
+    },
+    [patchTicket, selectedTicket]
+  );
+
+  const handleDialogUpdate = useCallback(
+    async (
+      workItemId: number,
+      updates: { title?: string; description?: string; resolution?: string }
+    ) => {
+      if (!selectedTicket || selectedTicket.id !== workItemId) return;
+      await patchTicket(workItemId, {
+        ...updates,
+        project: selectedTicket.project,
+        workItemType: selectedTicket.workItemType,
+      });
+    },
+    [patchTicket, selectedTicket]
+  );
+
+  const handleDialogTypeChange = useCallback(
+    async (workItemId: number, newType: string, additionalFields?: Record<string, string>) => {
+      if (!selectedTicket || selectedTicket.id !== workItemId) return;
+      const response = await devOpsPatch(`/api/devops/tickets/${workItemId}/type`, {
+        type: newType,
+        project: selectedTicket.project,
+        additionalFields,
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed to update work item type');
+      }
+      const data = await response.json().catch(() => ({}));
+      const updated = data.ticket as Ticket | undefined;
+      setSelectedTicket((prev) =>
+        prev && prev.id === workItemId
+          ? updated
+            ? {
+                ...updated,
+                createdAt: new Date(updated.createdAt),
+                updatedAt: new Date(updated.updatedAt),
+              }
+            : { ...prev, workItemType: newType }
+          : prev
+      );
+      fetchStandupData(true, true);
+    },
+    [devOpsPatch, selectedTicket, fetchStandupData]
   );
 
   const groups: GroupData[] = useMemo(() => {
@@ -366,6 +508,7 @@ function StandupPageContent() {
                     groupName={group.groupName}
                     columns={group.columns}
                     onStateChange={handleStateChange}
+                    onItemClick={handleItemClick}
                   />
                 ))
               ) : (
@@ -379,6 +522,29 @@ function StandupPageContent() {
             </div>
           ) : null}
         </div>
+
+        {/* Loading indicator while fetching the clicked ticket */}
+        {isLoadingTicket && !selectedTicket && (
+          <div
+            className="fixed inset-0 z-40 flex items-center justify-center"
+            style={{ backgroundColor: 'rgba(0, 0, 0, 0.4)' }}
+          >
+            <LoadingSpinner />
+          </div>
+        )}
+
+        {/* Detail dialog (issue #368) */}
+        <WorkItemDetailDialog
+          workItem={selectedTicket ? ticketToWorkItem(selectedTicket) : null}
+          isOpen={!!selectedTicket}
+          onClose={() => setSelectedTicket(null)}
+          onStateChange={handleDialogStateChange}
+          onAssigneeChange={handleDialogAssigneeChange}
+          onPriorityChange={handleDialogPriorityChange}
+          onTypeChange={handleDialogTypeChange}
+          onTagsChange={handleDialogTagsChange}
+          onUpdate={handleDialogUpdate}
+        />
       </div>
     </MainLayout>
   );

--- a/src/components/standup/KanbanGroupSection.tsx
+++ b/src/components/standup/KanbanGroupSection.tsx
@@ -27,11 +27,13 @@ function DroppableColumn({
   category,
   items,
   activeId,
+  onItemClick,
 }: {
   name: string;
   category: string;
   items: StandupWorkItem[];
   activeId: number | null;
+  onItemClick?: (item: StandupWorkItem) => void;
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: name });
   const color = getColumnColor(name, category);
@@ -54,7 +56,12 @@ function DroppableColumn({
       >
         <SortableContext items={items.map((i) => i.id)} strategy={verticalListSortingStrategy}>
           {items.map((item) => (
-            <StandupKanbanCard key={item.id} item={item} isDragging={activeId === item.id} />
+            <StandupKanbanCard
+              key={item.id}
+              item={item}
+              isDragging={activeId === item.id}
+              onClick={onItemClick}
+            />
           ))}
         </SortableContext>
 
@@ -72,12 +79,14 @@ interface KanbanGroupSectionProps {
   groupName: string;
   columns: StandupColumn[];
   onStateChange?: (itemId: number, targetState: string) => Promise<void>;
+  onItemClick?: (item: StandupWorkItem) => void;
 }
 
 export default function KanbanGroupSection({
   groupName,
   columns,
   onStateChange,
+  onItemClick,
 }: KanbanGroupSectionProps) {
   const columnNames = useMemo(() => columns.map((c) => c.name), [columns]);
   const totalItems = useMemo(() => columns.reduce((sum, c) => sum + c.items.length, 0), [columns]);
@@ -261,6 +270,7 @@ export default function KanbanGroupSection({
                     category={col.category}
                     items={items}
                     activeId={activeId}
+                    onItemClick={onItemClick}
                   />
                 );
               })}

--- a/src/components/standup/StandupKanbanCard.tsx
+++ b/src/components/standup/StandupKanbanCard.tsx
@@ -9,6 +9,9 @@ import type { StandupWorkItem } from '@/types';
 interface StandupKanbanCardProps {
   item: StandupWorkItem;
   isDragging?: boolean;
+  // When provided, clicks open the work item in a dialog instead of
+  // navigating to the full page (issue #368).
+  onClick?: (item: StandupWorkItem) => void;
 }
 
 const typeColors: Record<string, string> = {
@@ -20,7 +23,7 @@ const typeColors: Record<string, string> = {
   Risk: '#ff7b00',
 };
 
-export default function StandupKanbanCard({ item, isDragging }: StandupKanbanCardProps) {
+export default function StandupKanbanCard({ item, isDragging, onClick }: StandupKanbanCardProps) {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
     id: item.id,
   });
@@ -32,6 +35,53 @@ export default function StandupKanbanCard({ item, isDragging }: StandupKanbanCar
 
   const typeColor = typeColors[item.workItemType] || 'var(--text-muted)';
 
+  const cardBody = (
+    <>
+      <div className="mb-1.5 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5">
+          <span
+            className="rounded px-1 py-0.5 text-[10px] font-medium"
+            style={{
+              backgroundColor: `${typeColor}20`,
+              color: typeColor,
+            }}
+          >
+            {item.workItemType}
+          </span>
+          <span className="text-xs text-[var(--text-muted)]">#{item.id}</span>
+        </div>
+        <PriorityIndicator priority={item.priority} />
+      </div>
+
+      <h4 className="mb-2 line-clamp-2 text-sm font-medium text-[var(--text-primary)]">
+        {item.title}
+      </h4>
+
+      <div className="flex items-center justify-between gap-2">
+        {item.assignee ? (
+          <div className="flex min-w-0 items-center gap-1.5">
+            <Avatar name={item.assignee.displayName} image={item.assignee.avatarUrl} size="sm" />
+            <span className="max-w-[100px] truncate text-xs text-[var(--text-secondary)]">
+              {item.assignee.displayName}
+            </span>
+          </div>
+        ) : (
+          <span className="text-xs text-[var(--text-muted)] italic">Unassigned</span>
+        )}
+
+        {item.project && (
+          <span
+            className="max-w-[110px] truncate rounded bg-[var(--surface-hover)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--text-muted)]"
+            aria-label={`Project: ${item.project}`}
+            title={item.project}
+          >
+            {item.project}
+          </span>
+        )}
+      </div>
+    </>
+  );
+
   return (
     <div
       ref={setNodeRef}
@@ -40,50 +90,20 @@ export default function StandupKanbanCard({ item, isDragging }: StandupKanbanCar
       {...listeners}
       className={`kanban-card ${isDragging ? 'kanban-card-dragging' : ''}`}
     >
-      <Link href={`/tickets/${item.id}`} className="block">
-        <div className="mb-1.5 flex items-center justify-between gap-2">
-          <div className="flex items-center gap-1.5">
-            <span
-              className="rounded px-1 py-0.5 text-[10px] font-medium"
-              style={{
-                backgroundColor: `${typeColor}20`,
-                color: typeColor,
-              }}
-            >
-              {item.workItemType}
-            </span>
-            <span className="text-xs text-[var(--text-muted)]">#{item.id}</span>
-          </div>
-          <PriorityIndicator priority={item.priority} />
-        </div>
-
-        <h4 className="mb-2 line-clamp-2 text-sm font-medium text-[var(--text-primary)]">
-          {item.title}
-        </h4>
-
-        <div className="flex items-center justify-between gap-2">
-          {item.assignee ? (
-            <div className="flex min-w-0 items-center gap-1.5">
-              <Avatar name={item.assignee.displayName} image={item.assignee.avatarUrl} size="sm" />
-              <span className="max-w-[100px] truncate text-xs text-[var(--text-secondary)]">
-                {item.assignee.displayName}
-              </span>
-            </div>
-          ) : (
-            <span className="text-xs text-[var(--text-muted)] italic">Unassigned</span>
-          )}
-
-          {item.project && (
-            <span
-              className="max-w-[110px] truncate rounded bg-[var(--surface-hover)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--text-muted)]"
-              aria-label={`Project: ${item.project}`}
-              title={item.project}
-            >
-              {item.project}
-            </span>
-          )}
-        </div>
-      </Link>
+      {onClick ? (
+        <button
+          type="button"
+          onClick={() => onClick(item)}
+          className="block w-full text-left"
+          aria-label={`Open ${item.workItemType} #${item.id}`}
+        >
+          {cardBody}
+        </button>
+      ) : (
+        <Link href={`/tickets/${item.id}`} className="block">
+          {cardBody}
+        </Link>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Clicking a card on the Kanban board (`/kanban`) now opens the work item in the existing `WorkItemDetailDialog` instead of navigating to the full ticket page, matching how cards already behave on the Tickets / Work Items list.
- The dialog is fully editable from the Kanban: state, assignee, priority, type, tags, title, description, comments, attachments. Drag/drop state changes still flow through the existing handler.
- The board state (group expansion, scroll, filter) is preserved when the dialog closes.
<img width="1901" height="910" alt="image" src="https://github.com/user-attachments/assets/aba6d406-cce9-4405-9d37-e272d1765502" />



Fixes #368

## Implementation notes
- `StandupKanbanCard` gained an optional `onClick` prop; when set the card renders a `<button>` instead of a `<Link>` to the full page, so non-Kanban consumers are unaffected.
- `KanbanGroupSection` forwards an `onItemClick` callback down to each card.
- Kanban page fetches the full `Ticket` via `GET /api/devops/tickets/{id}` on click, converts it via `ticketToWorkItem`, and feeds the dialog. Dialog action handlers PATCH the work item and trigger a standup refresh so the board stays in sync.

## Test plan
- [x] Open `/kanban`, expand a group, click any card → dialog opens (no full-page navigation), card retains its place in the column on close
- [x] Edit assignee / priority / tags / title / description / state in the dialog → changes persist and the board reflects them after close
- [x] State change in the dialog also moves the card to the correct column on the next refresh
- [x] Drag/drop still updates the state and refreshes the board (regression check)
- [x] "Full View" button in the dialog still navigates to the full page
- [x] No regression on the Tickets-list-based Kanban (`/tickets?display=kanban`) — that path uses a separate component and shouldn't change

🤖 Generated with [Claude Code](https://claude.com/claude-code)