### PR TITLE
fix: +Add from Kanban creates an internal work item, not a ticket

### DIFF
--- a/src/app/api/devops/tickets/route.ts
+++ b/src/app/api/devops/tickets/route.ts
@@ -107,6 +107,7 @@ export async function POST(request: NextRequest) {
       areaPath,
       additionalFields,
       parentId,
+      asTicket,
     } = body;
 
     if (!project || !title) {
@@ -177,8 +178,14 @@ export async function POST(request: NextRequest) {
         ? parentId
         : undefined;
 
-    // Create the ticket with 'ticket' tag always included
-    const allTags = ['ticket', ...(tags || [])].filter(Boolean);
+    // Auto-tag with 'ticket' unless the caller explicitly opts out (asTicket: false).
+    // Defaulting to true preserves existing behaviour for any caller that omits
+    // the field — only the Kanban Board flow currently sets it false (issue #372).
+    const tagAsTicket = asTicket !== false;
+    const userTags = (tags || []).filter(Boolean) as string[];
+    const allTags = tagAsTicket
+      ? Array.from(new Set(['ticket', ...userTags]))
+      : userTags.filter((t) => t.toLowerCase() !== 'ticket');
     const workItem = await devopsService.createTicketWithAssignee(
       project,
       title,

--- a/src/app/api/devops/tickets/route.ts
+++ b/src/app/api/devops/tickets/route.ts
@@ -181,8 +181,13 @@ export async function POST(request: NextRequest) {
     // Auto-tag with 'ticket' unless the caller explicitly opts out (asTicket: false).
     // Defaulting to true preserves existing behaviour for any caller that omits
     // the field — only the Kanban Board flow currently sets it false (issue #372).
+    // Sanitize the user-supplied list to strings first; a malformed request with
+    // non-string entries would otherwise throw on .toLowerCase().
     const tagAsTicket = asTicket !== false;
-    const userTags = (tags || []).filter(Boolean) as string[];
+    const userTags = (Array.isArray(tags) ? tags : [])
+      .filter((t): t is string => typeof t === 'string')
+      .map((t) => t.trim())
+      .filter(Boolean);
     const allTags = tagAsTicket
       ? Array.from(new Set(['ticket', ...userTags]))
       : userTags.filter((t) => t.toLowerCase() !== 'ticket');

--- a/src/app/api/devops/tickets/route.ts
+++ b/src/app/api/devops/tickets/route.ts
@@ -188,6 +188,12 @@ export async function POST(request: NextRequest) {
       .filter((t): t is string => typeof t === 'string')
       .map((t) => t.trim())
       .filter(Boolean);
+    // Reject semicolons — DevOps uses ';' as the tag delimiter, so a single
+    // user-supplied tag containing ';' would silently split into multiple
+    // tags on the way through. Matches the PATCH handler.
+    if (userTags.some((t) => t.includes(';'))) {
+      return NextResponse.json({ error: 'Tags cannot contain semicolons' }, { status: 400 });
+    }
     // Drop any case-variant of "ticket" from user input first so the dedup is
     // case-insensitive — Set() with exact-string equality wouldn't catch
     // "Ticket" vs "ticket" and we'd end up with both.

--- a/src/app/api/devops/tickets/route.ts
+++ b/src/app/api/devops/tickets/route.ts
@@ -188,9 +188,11 @@ export async function POST(request: NextRequest) {
       .filter((t): t is string => typeof t === 'string')
       .map((t) => t.trim())
       .filter(Boolean);
-    const allTags = tagAsTicket
-      ? Array.from(new Set(['ticket', ...userTags]))
-      : userTags.filter((t) => t.toLowerCase() !== 'ticket');
+    // Drop any case-variant of "ticket" from user input first so the dedup is
+    // case-insensitive — Set() with exact-string equality wouldn't catch
+    // "Ticket" vs "ticket" and we'd end up with both.
+    const userTagsNoTicket = userTags.filter((t) => t.toLowerCase() !== 'ticket');
+    const allTags = tagAsTicket ? ['ticket', ...userTagsNoTicket] : userTagsNoTicket;
     const workItem = await devopsService.createTicketWithAssignee(
       project,
       title,

--- a/src/app/tickets/[id]/page.tsx
+++ b/src/app/tickets/[id]/page.tsx
@@ -8,6 +8,7 @@ import { MainLayout } from '@/components/layout';
 import { LoadingSpinner } from '@/components/common';
 import { TicketDetail } from '@/components/tickets';
 import { useOrganization } from '@/components/providers/OrganizationProvider';
+import { hasTicketTag } from '@/lib/tags';
 import type { Ticket, TicketComment, Attachment, WorkItemUpdate } from '@/types';
 
 export default function TicketDetailPage() {
@@ -58,7 +59,7 @@ export default function TicketDetailPage() {
         const data = await response.json();
         // Issue #372: route ticket vs internal work item to the URL that
         // matches its identity, so the sidebar highlight reflects reality.
-        const isTicket = (data.ticket.tags || []).includes('ticket');
+        const isTicket = hasTicketTag(data.ticket.tags);
         const onTicketsRoute = pathname?.startsWith('/tickets/');
         const onWorkItemsRoute = pathname?.startsWith('/workitems/');
         if (isTicket && onWorkItemsRoute) {

--- a/src/app/tickets/[id]/page.tsx
+++ b/src/app/tickets/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useSession } from 'next-auth/react';
-import { useRouter, useParams } from 'next/navigation';
+import { useRouter, useParams, usePathname } from 'next/navigation';
 import { useEffect, useState, useCallback } from 'react';
 import { toast } from 'sonner';
 import { MainLayout } from '@/components/layout';
@@ -14,6 +14,7 @@ export default function TicketDetailPage() {
   const { data: session, status } = useSession();
   const router = useRouter();
   const params = useParams();
+  const pathname = usePathname();
   const ticketId = params.id as string;
   const { selectedOrganization } = useOrganization();
 
@@ -55,6 +56,19 @@ export default function TicketDetailPage() {
       });
       if (response.ok) {
         const data = await response.json();
+        // Issue #372: route ticket vs internal work item to the URL that
+        // matches its identity, so the sidebar highlight reflects reality.
+        const isTicket = (data.ticket.tags || []).includes('ticket');
+        const onTicketsRoute = pathname?.startsWith('/tickets/');
+        const onWorkItemsRoute = pathname?.startsWith('/workitems/');
+        if (isTicket && onWorkItemsRoute) {
+          router.replace(`/tickets/${ticketId}`);
+          return;
+        }
+        if (!isTicket && onTicketsRoute) {
+          router.replace(`/workitems/${ticketId}`);
+          return;
+        }
         setTicket({
           ...data.ticket,
           createdAt: new Date(data.ticket.createdAt),
@@ -80,7 +94,7 @@ export default function TicketDetailPage() {
     } finally {
       setLoading(false);
     }
-  }, [ticketId, router, selectedOrganization, orgHeaders]);
+  }, [ticketId, router, selectedOrganization, orgHeaders, pathname]);
 
   const fetchHistory = useCallback(async () => {
     setHistoryLoading(true);

--- a/src/app/tickets/[id]/page.tsx
+++ b/src/app/tickets/[id]/page.tsx
@@ -94,12 +94,14 @@ export default function TicketDetailPage() {
         );
       } else {
         isRedirecting = true;
-        router.push('/tickets');
+        // Send users back to a sensible list for whichever route they were on
+        // — Kanban Board is the natural home for internal work items.
+        router.push(pathname?.startsWith('/workitems/') ? '/kanban' : '/tickets');
       }
     } catch (error) {
       console.error('Failed to fetch ticket:', error);
       isRedirecting = true;
-      router.push('/tickets');
+      router.push(pathname?.startsWith('/workitems/') ? '/kanban' : '/tickets');
     } finally {
       if (!isRedirecting) setLoading(false);
     }

--- a/src/app/tickets/[id]/page.tsx
+++ b/src/app/tickets/[id]/page.tsx
@@ -51,6 +51,10 @@ export default function TicketDetailPage() {
   const fetchTicket = useCallback(async () => {
     if (!selectedOrganization) return;
     setLoading(true);
+    // Track whether we kicked off a route-replace so the finally block knows
+    // not to flip loading off — otherwise we render `null` (blank page) for
+    // a beat until the new route mounts.
+    let isRedirecting = false;
     try {
       const response = await fetch(`/api/devops/tickets/${ticketId}`, {
         headers: orgHeaders(),
@@ -63,10 +67,12 @@ export default function TicketDetailPage() {
         const onTicketsRoute = pathname?.startsWith('/tickets/');
         const onWorkItemsRoute = pathname?.startsWith('/workitems/');
         if (isTicket && onWorkItemsRoute) {
+          isRedirecting = true;
           router.replace(`/tickets/${ticketId}`);
           return;
         }
         if (!isTicket && onTicketsRoute) {
+          isRedirecting = true;
           router.replace(`/workitems/${ticketId}`);
           return;
         }
@@ -87,13 +93,15 @@ export default function TicketDetailPage() {
             )
         );
       } else {
+        isRedirecting = true;
         router.push('/tickets');
       }
     } catch (error) {
       console.error('Failed to fetch ticket:', error);
+      isRedirecting = true;
       router.push('/tickets');
     } finally {
-      setLoading(false);
+      if (!isRedirecting) setLoading(false);
     }
   }, [ticketId, router, selectedOrganization, orgHeaders, pathname]);
 

--- a/src/app/workitems/[id]/page.tsx
+++ b/src/app/workitems/[id]/page.tsx
@@ -1,0 +1,6 @@
+// Internal work items (created from the Kanban Board, no "ticket" tag)
+// share the same detail UI as tickets but live under a different route so
+// the sidebar doesn't highlight Tickets when viewing one (issue #372).
+'use client';
+
+export { default } from '@/app/tickets/[id]/page';

--- a/src/components/tickets/CommentSection.tsx
+++ b/src/components/tickets/CommentSection.tsx
@@ -15,6 +15,9 @@ interface CommentSectionProps {
   assignee?: User | null;
   onZapClick?: () => void;
   compact?: boolean;
+  // false → internal work item (no customer-facing copy). Defaults to true
+  // so existing callers keep their ticket-style helper text.
+  isTicket?: boolean;
 }
 
 export default function CommentSection({
@@ -25,6 +28,7 @@ export default function CommentSection({
   assignee,
   onZapClick,
   compact = false,
+  isTicket = true,
 }: CommentSectionProps) {
   const [newComment, setNewComment] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -179,7 +183,9 @@ export default function CommentSection({
                   className="h-4 w-4 rounded accent-[var(--primary)]"
                 />
                 <span className="text-xs" style={{ color: 'var(--primary)' }}>
-                  Public reply – all comments are visible to customers in DevOps
+                  {isTicket
+                    ? 'Public reply – all comments are visible to customers in DevOps'
+                    : 'Comments are visible in DevOps'}
                 </span>
               </label>
             </div>

--- a/src/components/tickets/NewTicketDialog.tsx
+++ b/src/components/tickets/NewTicketDialog.tsx
@@ -614,7 +614,8 @@ export default function NewTicketDialog({ isOpen, onClose }: NewTicketDialogProp
         router.push(`/tickets/${ticketId}`);
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create ticket');
+      const fallback = isKanbanContext ? 'Failed to create work item' : 'Failed to create ticket';
+      setError(err instanceof Error ? err.message : fallback);
     } finally {
       setIsSubmitting(false);
       setIsUploadingFiles(false);

--- a/src/components/tickets/NewTicketDialog.tsx
+++ b/src/components/tickets/NewTicketDialog.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { X, Send, Loader2, Search, Paperclip } from 'lucide-react';
 import { useDevOpsApi } from '@/hooks/useDevOpsApi';
 import MentionInput from '@/components/common/MentionInput';
@@ -63,6 +63,11 @@ interface NewTicketDialogProps {
 export default function NewTicketDialog({ isOpen, onClose }: NewTicketDialogProps) {
   const { data: session } = useSession();
   const router = useRouter();
+  const pathname = usePathname();
+  // When opened from the Kanban Board, treat the new item as an internal
+  // work item, not a customer ticket: no auto "ticket" tag, no SLA, hidden
+  // from the Tickets screen (issue #372).
+  const isKanbanContext = pathname?.startsWith('/kanban') ?? false;
   const { get, post, hasOrganization } = useDevOpsApi();
   const [projects, setProjects] = useState<DevOpsProject[]>([]);
   const [teamMembers, setTeamMembers] = useState<User[]>([]);
@@ -562,6 +567,9 @@ export default function NewTicketDialog({ isOpen, onClose }: NewTicketDialogProp
           .filter(Boolean),
         additionalFields: Object.keys(additionalFields).length > 0 ? additionalFields : undefined,
         parentId: effectiveParentId ?? undefined,
+        // Kanban Board context: create as a plain internal work item (no
+        // "ticket" tag → invisible to the Tickets screen and SLA tracking)
+        asTicket: !isKanbanContext,
       });
 
       if (!response.ok) {
@@ -600,7 +608,11 @@ export default function NewTicketDialog({ isOpen, onClose }: NewTicketDialogProp
       }
 
       onClose();
-      router.push(`/tickets/${ticketId}`);
+      // Kanban Board: stay on the board so the user sees the new item there.
+      // Other contexts: jump to the new ticket's detail page.
+      if (!isKanbanContext) {
+        router.push(`/tickets/${ticketId}`);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create ticket');
     } finally {
@@ -661,7 +673,7 @@ export default function NewTicketDialog({ isOpen, onClose }: NewTicketDialogProp
               New
             </span>
             <h2 className="text-lg font-semibold" style={{ color: 'var(--text-primary)' }}>
-              Create Ticket
+              {isKanbanContext ? 'Create Work Item' : 'Create Ticket'}
             </h2>
           </div>
           <button
@@ -1057,7 +1069,9 @@ export default function NewTicketDialog({ isOpen, onClose }: NewTicketDialogProp
                   className="input w-full"
                 />
                 <p className="mt-1 text-xs" style={{ color: 'var(--text-muted)' }}>
-                  Comma-separated. &quot;ticket&quot; tag added automatically.
+                  {isKanbanContext
+                    ? 'Comma-separated. Internal work item — no "ticket" tag, hidden from the Tickets screen.'
+                    : 'Comma-separated. "ticket" tag added automatically.'}
                 </p>
               </div>
 

--- a/src/components/tickets/TicketDetail.tsx
+++ b/src/components/tickets/TicketDetail.tsx
@@ -35,6 +35,7 @@ import { ALLOWED_ATTACHMENT_TYPES } from '@/types';
 import { ensureActiveState } from '@/types';
 import { highlightMentions } from '@/lib/mentions';
 import { formatFileSize, validateFile } from '@/lib/attachment-utils';
+import { hasTicketTag } from '@/lib/tags';
 import StatusBadge from '../common/StatusBadge';
 import Avatar from '../common/Avatar';
 import PriorityIndicator from '../common/PriorityIndicator';
@@ -106,7 +107,7 @@ export default function TicketDetail({
   // Items without the "ticket" tag are internal work items (created from the
   // Kanban Board, etc.) — they have no customer-facing surface so the page
   // should read as a Work Item, not a Ticket (issue #372).
-  const isTicket = ticket.tags.includes('ticket');
+  const isTicket = hasTicketTag(ticket.tags);
   const [activeTab, setActiveTab] = useState<DetailTab>('details');
   const [newComment, setNewComment] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/src/components/tickets/TicketDetail.tsx
+++ b/src/components/tickets/TicketDetail.tsx
@@ -103,6 +103,10 @@ export default function TicketDetail({
   const templateConfig = getTemplateConfig(processTemplate);
   const showResolution = hasResolutionField(ticket.workItemType, templateConfig);
   const showMitigation = hasMitigationField(ticket.workItemType, templateConfig);
+  // Items without the "ticket" tag are internal work items (created from the
+  // Kanban Board, etc.) — they have no customer-facing surface so the page
+  // should read as a Work Item, not a Ticket (issue #372).
+  const isTicket = ticket.tags.includes('ticket');
   const [activeTab, setActiveTab] = useState<DetailTab>('details');
   const [newComment, setNewComment] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -1225,7 +1229,9 @@ export default function TicketDetail({
                 className="h-4 w-4 rounded accent-[var(--primary)]"
               />
               <span className="text-xs" style={{ color: 'var(--primary)' }}>
-                Public reply – all comments are visible to customers in DevOps
+                {isTicket
+                  ? 'Public reply – all comments are visible to customers in DevOps'
+                  : 'Comments are visible in DevOps'}
               </span>
             </label>
           </div>
@@ -1356,7 +1362,7 @@ export default function TicketDetail({
         <div className="p-4">
           <div className="mb-4 flex items-center justify-between">
             <h3 className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
-              Ticket Details
+              {isTicket ? 'Ticket Details' : 'Work Item Details'}
             </h3>
             <button
               onClick={() => setIsDetailsSidebarOpen(false)}

--- a/src/components/tickets/WorkItemDetailContent.tsx
+++ b/src/components/tickets/WorkItemDetailContent.tsx
@@ -272,6 +272,9 @@ export default function WorkItemDetailContent({
   const templateConfig = getTemplateConfig(processTemplate);
   const showResolution = hasResolutionField(workItem.workItemType, templateConfig);
   const showMitigation = hasMitigationField(workItem.workItemType, templateConfig);
+  // Internal work items (no "ticket" tag) have no customer-facing surface, so
+  // the comment helper should drop the "visible to customers" wording (#372).
+  const isTicket = workItem.tags?.includes('ticket') ?? true;
 
   // Edit mode state
   const [isEditing, setIsEditing] = useState(false);
@@ -494,6 +497,7 @@ export default function WorkItemDetailContent({
             assignee={workItem.assignee}
             onZapClick={() => setIsZapDialogOpen(true)}
             compact
+            isTicket={isTicket}
           />
         </div>
       ) : (
@@ -504,6 +508,7 @@ export default function WorkItemDetailContent({
           onUploadAttachment={onUploadAttachment}
           assignee={workItem.assignee}
           onZapClick={() => setIsZapDialogOpen(true)}
+          isTicket={isTicket}
         />
       )}
 

--- a/src/components/tickets/WorkItemDetailContent.tsx
+++ b/src/components/tickets/WorkItemDetailContent.tsx
@@ -9,6 +9,7 @@ import {
   hasMitigationField,
   hasResolutionField,
 } from '@/config/process-templates';
+import { hasTicketTag } from '@/lib/tags';
 import Avatar from '../common/Avatar';
 import CommentSection from './CommentSection';
 import ZapDialog from './ZapDialog';
@@ -274,7 +275,9 @@ export default function WorkItemDetailContent({
   const showMitigation = hasMitigationField(workItem.workItemType, templateConfig);
   // Internal work items (no "ticket" tag) have no customer-facing surface, so
   // the comment helper should drop the "visible to customers" wording (#372).
-  const isTicket = workItem.tags?.includes('ticket') ?? true;
+  // Default to true when tags are missing so we don't accidentally hide ticket
+  // copy from a real ticket whose details haven't fully loaded yet.
+  const isTicket = workItem.tags ? hasTicketTag(workItem.tags) : true;
 
   // Edit mode state
   const [isEditing, setIsEditing] = useState(false);

--- a/src/components/tickets/WorkItemDetailDialog.tsx
+++ b/src/components/tickets/WorkItemDetailDialog.tsx
@@ -9,6 +9,7 @@ import StatusBadge from '../common/StatusBadge';
 import TicketDialogShell from './TicketDialogShell';
 import { useWorkItemActions } from '@/hooks/useWorkItemActions';
 import { useDevOpsApi } from '@/hooks/useDevOpsApi';
+import { hasTicketTag } from '@/lib/tags';
 import WorkItemDetailContent from './WorkItemDetailContent';
 import WorkItemDetailSidebar from './WorkItemDetailSidebar';
 import TypeChangeRequiredFields from './TypeChangeRequiredFields';
@@ -312,8 +313,9 @@ export default function WorkItemDetailDialog({
       <button
         onClick={() => {
           // Internal work items (no "ticket" tag) live at /workitems/[id]
-          // so the sidebar doesn't highlight Tickets (issue #372).
-          const isTicket = workItem.tags?.includes('ticket') ?? true;
+          // so the sidebar doesn't highlight Tickets (issue #372). Default
+          // to ticket routing when tags aren't loaded yet.
+          const isTicket = workItem.tags ? hasTicketTag(workItem.tags) : true;
           router.push(`${isTicket ? '/tickets' : '/workitems'}/${workItem.id}`);
           onClose();
         }}

--- a/src/components/tickets/WorkItemDetailDialog.tsx
+++ b/src/components/tickets/WorkItemDetailDialog.tsx
@@ -311,7 +311,10 @@ export default function WorkItemDetailDialog({
     <>
       <button
         onClick={() => {
-          router.push(`/tickets/${workItem.id}`);
+          // Internal work items (no "ticket" tag) live at /workitems/[id]
+          // so the sidebar doesn't highlight Tickets (issue #372).
+          const isTicket = workItem.tags?.includes('ticket') ?? true;
+          router.push(`${isTicket ? '/tickets' : '/workitems'}/${workItem.id}`);
           onClose();
         }}
         className="flex items-center gap-1 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-[var(--surface-hover)]"

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,0 +1,9 @@
+// Shared tag helpers. The "ticket" tag is the marker that flags a work item
+// as a customer-facing ticket (vs an internal work item created from the
+// Kanban Board). Tag casing isn't preserved consistently across DevOps users
+// so all checks here are case-insensitive.
+
+export function hasTicketTag(tags: readonly string[] | null | undefined): boolean {
+  if (!tags) return false;
+  return tags.some((t) => typeof t === 'string' && t.toLowerCase() === 'ticket');
+}


### PR DESCRIPTION
## Summary

When the +Add dialog is opened from the **Kanban Board**, the new item is now created as a plain internal work item — no auto \`ticket\` tag, no SLA tracking, hidden from the Tickets screen. Other entry points (Tickets +Add, email channel, Monthly Checkpoint) are unchanged and still produce real customer tickets.
<img width="1899" height="914" alt="image" src="https://github.com/user-attachments/assets/5a1c292b-2db6-4531-b850-e80ea2172f08" />


## What changed

- **Server** — \`POST /api/devops/tickets\` accepts \`asTicket: false\` to skip the auto-\`ticket\` tag (and strip a user-supplied \`ticket\` for safety). Defaults to \`true\`, so existing callers behave identically.
- **Dialog** — \`NewTicketDialog\` reads the current pathname via \`usePathname\`. On \`/kanban\` it sends \`asTicket: false\`, the title reads "Create Work Item", the Tags helper text updates, and post-create the user stays on the Kanban Board instead of being pushed to \`/tickets/[id]\`.
- **Routing** — internal work items get their own route at \`/workitems/[id]\` (thin re-export of the existing detail page) so the sidebar's Tickets nav item doesn't light up when viewing one. The detail page redirects mismatched URLs to keep the route consistent with the item's identity (real ticket → \`/tickets/[id]\`, work item → \`/workitems/[id]\`).
- **Copy** — \`TicketDetail\` and \`CommentSection\` derive an \`isTicket\` flag from the \`ticket\` tag and switch labels to "Work Item Details" / "Comments are visible in DevOps" when the item has no customer-facing surface. Real tickets keep "Ticket Details" / "Public reply – all comments are visible to customers in DevOps".
- **Dialog "Full View" button** — routes to \`/tickets/[id]\` or \`/workitems/[id]\` based on the item's tag.

## Why server-side too

Tagging is enforced both server- and client-side. A future entry point (e.g. an API consumer) can opt out of the ticket tag the same way the Kanban dialog does, without each new caller having to remember to strip the tag from the request body.

Fixes #372

## Test plan

- [x] Open \`/kanban\` → click **+ Add** in the sidebar → dialog title reads "Create Work Item" and Tags helper says no "ticket" tag is added
- [x] Submit → new work item is created without the \`ticket\` tag, dialog closes, you stay on the Kanban Board
- [x] Open the new item from the board → URL is \`/workitems/[id]\`, sidebar **does not** highlight Tickets, detail page reads "Work Item Details"
- [x] Search the Tickets screen for the new item → does not appear (it has no \`ticket\` tag)
- [x] On any other page (\`/tickets\`, \`/monthly-checkpoint\`, etc.) click **+ Add** → dialog still reads "Create Ticket" and behaves as before; created item appears in the Tickets list and lands on \`/tickets/[id]\`
- [x] Open an existing real ticket → URL is \`/tickets/[id]\`, sidebar highlights Tickets, detail page reads "Ticket Details" with the existing public-reply helper
- [x] Type \`/tickets/<id-of-internal-work-item>\` directly into the address bar → page detects mismatch and redirects to \`/workitems/[id]\`
- [x] Type \`/workitems/<id-of-real-ticket>\` directly → redirects to \`/tickets/[id]\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)