### PR TITLE
feat: delete a ticket / work item from ZapDesk

### DIFF
--- a/src/app/api/devops/tickets/[id]/route.ts
+++ b/src/app/api/devops/tickets/[id]/route.ts
@@ -51,6 +51,59 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   }
 }
 
+// DELETE moves the work item to the DevOps Recycle Bin (reversible).
+// Pass ?destroy=true to permanently destroy it (admins only) — this still
+// requires the user's PAT/OAuth token to have the destroy permission in DevOps.
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.accessToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+    const ticketId = parseInt(id, 10);
+
+    if (isNaN(ticketId) || ticketId <= 0) {
+      return NextResponse.json({ error: 'Invalid ticket ID' }, { status: 400 });
+    }
+
+    const destroy = request.nextUrl.searchParams.get('destroy') === 'true';
+    const organization = request.headers.get('x-devops-org') || undefined;
+    const devopsService = new AzureDevOpsService(session.accessToken, organization);
+
+    try {
+      await devopsService.deleteWorkItem(ticketId, destroy);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to delete';
+      // Map upstream auth failures to a clear status so the client can toast nicely
+      if (/\b401\b/.test(message)) {
+        return NextResponse.json(
+          { error: 'Unauthorized to delete this work item' },
+          { status: 401 }
+        );
+      }
+      if (/\b403\b/.test(message)) {
+        return NextResponse.json(
+          { error: 'You do not have permission to delete this work item in DevOps' },
+          { status: 403 }
+        );
+      }
+      if (/\b404\b/.test(message)) {
+        return NextResponse.json({ error: 'Work item not found' }, { status: 404 });
+      }
+      throw err;
+    }
+
+    return NextResponse.json({ success: true, id: ticketId, destroyed: destroy });
+  } catch (error) {
+    console.error('Error deleting ticket:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Failed to delete ticket';
+    return NextResponse.json({ error: errorMessage }, { status: 500 });
+  }
+}
+
 export async function PATCH(request: NextRequest, { params }: RouteParams) {
   try {
     const session = await getServerSession(authOptions);

--- a/src/app/api/devops/tickets/[id]/route.ts
+++ b/src/app/api/devops/tickets/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
-import { AzureDevOpsService, workItemToTicket } from '@/lib/devops';
+import { AzureDevOpsService, DevOpsApiError, workItemToTicket } from '@/lib/devops';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -52,8 +52,9 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 }
 
 // DELETE moves the work item to the DevOps Recycle Bin (reversible).
-// Pass ?destroy=true to permanently destroy it (admins only) — this still
-// requires the user's PAT/OAuth token to have the destroy permission in DevOps.
+// Pass ?destroy=true to permanently destroy it. Authorization is enforced
+// by DevOps based on the user's role/PAT scope — there is no ZapDesk-side
+// admin gate yet (tracked as a follow-up; see PR #375 description).
 export async function DELETE(request: NextRequest, { params }: RouteParams) {
   try {
     const session = await getServerSession(authOptions);
@@ -76,22 +77,23 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     try {
       await devopsService.deleteWorkItem(ticketId, destroy);
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to delete';
-      // Map upstream auth failures to a clear status so the client can toast nicely
-      if (/\b401\b/.test(message)) {
-        return NextResponse.json(
-          { error: 'Unauthorized to delete this work item' },
-          { status: 401 }
-        );
-      }
-      if (/\b403\b/.test(message)) {
-        return NextResponse.json(
-          { error: 'You do not have permission to delete this work item in DevOps' },
-          { status: 403 }
-        );
-      }
-      if (/\b404\b/.test(message)) {
-        return NextResponse.json({ error: 'Work item not found' }, { status: 404 });
+      // Map structured upstream failures to clean client-facing statuses
+      if (err instanceof DevOpsApiError) {
+        if (err.status === 401) {
+          return NextResponse.json(
+            { error: 'Unauthorized to delete this work item' },
+            { status: 401 }
+          );
+        }
+        if (err.status === 403) {
+          return NextResponse.json(
+            { error: 'You do not have permission to delete this work item in DevOps' },
+            { status: 403 }
+          );
+        }
+        if (err.status === 404) {
+          return NextResponse.json({ error: 'Work item not found' }, { status: 404 });
+        }
       }
       throw err;
     }

--- a/src/app/api/devops/tickets/[id]/route.ts
+++ b/src/app/api/devops/tickets/[id]/route.ts
@@ -54,7 +54,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 // DELETE moves the work item to the DevOps Recycle Bin (reversible).
 // Pass ?destroy=true to permanently destroy it. Authorization is enforced
 // by DevOps based on the user's role/PAT scope — there is no ZapDesk-side
-// admin gate yet (tracked as a follow-up; see PR #375 description).
+// admin gate yet (a follow-up to issue #374).
 export async function DELETE(request: NextRequest, { params }: RouteParams) {
   try {
     const session = await getServerSession(authOptions);
@@ -100,9 +100,10 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
 
     return NextResponse.json({ success: true, id: ticketId, destroyed: destroy });
   } catch (error) {
+    // Log full detail server-side; return a generic message so the client
+    // toast doesn't echo upstream / internal error text.
     console.error('Error deleting ticket:', error);
-    const errorMessage = error instanceof Error ? error.message : 'Failed to delete ticket';
-    return NextResponse.json({ error: errorMessage }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to delete ticket' }, { status: 500 });
   }
 }
 

--- a/src/app/tickets/[id]/page.tsx
+++ b/src/app/tickets/[id]/page.tsx
@@ -315,6 +315,26 @@ export default function TicketDetailPage() {
     }
   };
 
+  // Delete (Recycle Bin) — issue #374. Confirmation is rendered by TicketDetail.
+  const handleDelete = async () => {
+    if (!ticket) return;
+    try {
+      const response = await fetch(`/api/devops/tickets/${ticketId}`, {
+        method: 'DELETE',
+        headers: orgHeaders(),
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed to delete');
+      }
+      toast.success(`Deleted #${ticketId}`);
+      router.push('/tickets');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to delete');
+      throw err;
+    }
+  };
+
   const handleUploadAttachment = async (file: File): Promise<Attachment> => {
     const formData = new FormData();
     formData.append('file', file);
@@ -366,6 +386,7 @@ export default function TicketDetailPage() {
         onMitigationChange={handleMitigationChange}
         onUploadAttachment={handleUploadAttachment}
         onRefreshTicket={fetchTicket}
+        onDelete={handleDelete}
       />
     </MainLayout>
   );

--- a/src/app/tickets/[id]/page.tsx
+++ b/src/app/tickets/[id]/page.tsx
@@ -341,6 +341,9 @@ export default function TicketDetailPage() {
   };
 
   // Delete (Recycle Bin) — issue #374. Confirmation is rendered by TicketDetail.
+  // Errors are surfaced via toast here; do not rethrow — the caller invokes
+  // this from an onClick handler that React doesn't await, so a rejection
+  // would land as an unhandled promise rejection in the browser console.
   const handleDelete = async () => {
     if (!ticket) return;
     try {
@@ -356,7 +359,6 @@ export default function TicketDetailPage() {
       router.push('/tickets');
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to delete');
-      throw err;
     }
   };
 

--- a/src/components/tickets/TicketDetail.tsx
+++ b/src/components/tickets/TicketDetail.tsx
@@ -126,8 +126,9 @@ export default function TicketDetail({
     try {
       await onDelete();
     } catch {
-      // Caller already toasts on failure; just clear local state so the
-      // button becomes interactive again.
+      // Caller already toasts on failure; we just need the local state
+      // cleared via the finally block so the button becomes interactive again.
+    } finally {
       setIsDeleting(false);
     }
   };
@@ -726,7 +727,7 @@ export default function TicketDetail({
                 onClick={handleDeleteClick}
                 disabled={isDeleting}
                 className="hidden items-center gap-1 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-[var(--surface-hover)] disabled:cursor-not-allowed disabled:opacity-50 sm:flex"
-                style={{ color: '#ef4444', cursor: 'pointer' }}
+                style={{ color: '#ef4444', cursor: isDeleting ? 'not-allowed' : 'pointer' }}
                 title="Delete (move to DevOps Recycle Bin)"
                 aria-label="Delete ticket"
               >

--- a/src/components/tickets/TicketDetail.tsx
+++ b/src/components/tickets/TicketDetail.tsx
@@ -19,6 +19,7 @@ import {
   Download,
   Plus,
   Tag,
+  Trash2,
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import type {
@@ -71,6 +72,9 @@ interface TicketDetailProps {
   onMitigationChange?: (mitigation: string) => Promise<void>;
   onUploadAttachment?: (file: File) => Promise<Attachment>;
   onRefreshTicket?: () => Promise<void>;
+  // Move to DevOps Recycle Bin. Caller is responsible for navigation/refresh
+  // after success (issue #374).
+  onDelete?: () => Promise<void>;
   processTemplate?: string;
 }
 
@@ -97,6 +101,7 @@ export default function TicketDetail({
   onMitigationChange,
   onUploadAttachment,
   onRefreshTicket,
+  onDelete,
   processTemplate,
 }: TicketDetailProps) {
   const router = useRouter();
@@ -108,7 +113,24 @@ export default function TicketDetail({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isZapDialogOpen, setIsZapDialogOpen] = useState(false);
   const [isDetailsSidebarOpen, setIsDetailsSidebarOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
   const { get: devOpsGet } = useDevOpsApi();
+
+  const handleDeleteClick = async () => {
+    if (!onDelete || isDeleting) return;
+    const confirmed = window.confirm(
+      `Move "${ticket.title}" (#${ticket.id}) to the DevOps Recycle Bin?\n\nIt will be removed from ZapDesk views. You can restore it from the DevOps Recycle Bin if needed.`
+    );
+    if (!confirmed) return;
+    setIsDeleting(true);
+    try {
+      await onDelete();
+    } catch {
+      // Caller already toasts on failure; just clear local state so the
+      // button becomes interactive again.
+      setIsDeleting(false);
+    }
+  };
 
   // State editing
   const [isStateDropdownOpen, setIsStateDropdownOpen] = useState(false);
@@ -698,6 +720,20 @@ export default function TicketDetail({
             >
               View in DevOps <ExternalLink size={14} />
             </a>
+            {onDelete && (
+              <button
+                type="button"
+                onClick={handleDeleteClick}
+                disabled={isDeleting}
+                className="hidden items-center gap-1 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-[var(--surface-hover)] disabled:cursor-not-allowed disabled:opacity-50 sm:flex"
+                style={{ color: '#ef4444', cursor: 'pointer' }}
+                title="Delete (move to DevOps Recycle Bin)"
+                aria-label="Delete ticket"
+              >
+                {isDeleting ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
+                Delete
+              </button>
+            )}
           </div>
 
           <div className="flex items-center gap-4">

--- a/src/components/tickets/TicketDetail.tsx
+++ b/src/components/tickets/TicketDetail.tsx
@@ -123,11 +123,11 @@ export default function TicketDetail({
     );
     if (!confirmed) return;
     setIsDeleting(true);
+    // Don't swallow — let the consumer's onDelete decide how to surface
+    // failure (toast, redirect, etc.). finally guarantees the button is
+    // re-enabled either way.
     try {
       await onDelete();
-    } catch {
-      // Caller already toasts on failure; we just need the local state
-      // cleared via the finally block so the button becomes interactive again.
     } finally {
       setIsDeleting(false);
     }

--- a/src/components/tickets/WorkItemDetailDialog.tsx
+++ b/src/components/tickets/WorkItemDetailDialog.tsx
@@ -57,6 +57,12 @@ export default function WorkItemDetailDialog({
 
   const handleDelete = useCallback(async () => {
     if (!workItem || isDeleting) return;
+    // Bail before showing the confirm — fetchDevOps would throw "No organization
+    // selected" anyway, but only after the user committed to the action.
+    if (!hasOrganization) {
+      toast.error('Select an organization before deleting');
+      return;
+    }
     const confirmed = window.confirm(
       `Move "${workItem.title}" (#${workItem.id}) to the DevOps Recycle Bin?\n\nIt will be removed from ZapDesk views. You can restore it from the DevOps Recycle Bin if needed.`
     );
@@ -78,7 +84,7 @@ export default function WorkItemDetailDialog({
     } finally {
       setIsDeleting(false);
     }
-  }, [workItem, isDeleting, fetchDevOps, onDeleted, onClose]);
+  }, [workItem, isDeleting, hasOrganization, fetchDevOps, onDeleted, onClose]);
 
   // Bind workItemId into callbacks for the hook
   const boundStateChange = useCallback(

--- a/src/components/tickets/WorkItemDetailDialog.tsx
+++ b/src/components/tickets/WorkItemDetailDialog.tsx
@@ -358,20 +358,18 @@ export default function WorkItemDetailDialog({
       >
         DevOps <ExternalLink size={14} />
       </a>
-      {onDeleted && (
-        <button
-          type="button"
-          onClick={handleDelete}
-          disabled={isDeleting}
-          className="flex items-center gap-1 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-[var(--surface-hover)] disabled:cursor-not-allowed disabled:opacity-50"
-          style={{ color: '#ef4444', cursor: 'pointer' }}
-          title="Delete (move to DevOps Recycle Bin)"
-          aria-label="Delete work item"
-        >
-          {isDeleting ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
-          Delete
-        </button>
-      )}
+      <button
+        type="button"
+        onClick={handleDelete}
+        disabled={isDeleting}
+        className="flex items-center gap-1 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-[var(--surface-hover)] disabled:cursor-not-allowed disabled:opacity-50"
+        style={{ color: '#ef4444', cursor: isDeleting ? 'not-allowed' : 'pointer' }}
+        title="Delete (move to DevOps Recycle Bin)"
+        aria-label="Delete work item"
+      >
+        {isDeleting ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
+        Delete
+      </button>
     </>
   );
 

--- a/src/components/tickets/WorkItemDetailDialog.tsx
+++ b/src/components/tickets/WorkItemDetailDialog.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
-import { ExternalLink, ChevronDown, Loader2, Maximize2 } from 'lucide-react';
+import { ExternalLink, ChevronDown, Loader2, Maximize2, Trash2 } from 'lucide-react';
 import type { WorkItem, TicketComment, Attachment } from '@/types';
 import StatusBadge from '../common/StatusBadge';
 import TicketDialogShell from './TicketDialogShell';
@@ -51,6 +51,34 @@ export default function WorkItemDetailDialog({
   // Comments state (dialog fetches its own comments)
   const [comments, setComments] = useState<TicketComment[]>([]);
   const [isLoadingComments, setIsLoadingComments] = useState(false);
+
+  // Delete (Recycle Bin) state — issue #374
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = useCallback(async () => {
+    if (!workItem || isDeleting) return;
+    const confirmed = window.confirm(
+      `Move "${workItem.title}" (#${workItem.id}) to the DevOps Recycle Bin?\n\nIt will be removed from ZapDesk views. You can restore it from the DevOps Recycle Bin if needed.`
+    );
+    if (!confirmed) return;
+    setIsDeleting(true);
+    try {
+      const response = await fetchDevOps(`/api/devops/tickets/${workItem.id}`, {
+        method: 'DELETE',
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed to delete');
+      }
+      toast.success(`Deleted #${workItem.id}`);
+      onDeleted?.(workItem.id);
+      onClose();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to delete');
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [workItem, isDeleting, fetchDevOps, onDeleted, onClose]);
 
   // Bind workItemId into callbacks for the hook
   const boundStateChange = useCallback(
@@ -330,6 +358,20 @@ export default function WorkItemDetailDialog({
       >
         DevOps <ExternalLink size={14} />
       </a>
+      {onDeleted && (
+        <button
+          type="button"
+          onClick={handleDelete}
+          disabled={isDeleting}
+          className="flex items-center gap-1 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-[var(--surface-hover)] disabled:cursor-not-allowed disabled:opacity-50"
+          style={{ color: '#ef4444', cursor: 'pointer' }}
+          title="Delete (move to DevOps Recycle Bin)"
+          aria-label="Delete work item"
+        >
+          {isDeleting ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
+          Delete
+        </button>
+      )}
     </>
   );
 

--- a/src/lib/devops.ts
+++ b/src/lib/devops.ts
@@ -1043,10 +1043,14 @@ export class AzureDevOpsService {
     });
 
     if (!response.ok) {
-      const errorText = await response.text().catch(() => '');
+      // Truncate upstream body so a verbose HTML/JSON error page can't blow up
+      // logs or echo internal details back to the client via the thrown message.
+      const rawBody = await response.text().catch(() => '');
+      const snippet = rawBody.slice(0, 200).trim();
+      const tail = rawBody.length > snippet.length ? '…' : '';
       throw new DevOpsApiError(
         response.status,
-        `Failed to delete work item: ${response.status} ${response.statusText}${errorText ? ' - ' + errorText : ''}`
+        `Failed to delete work item: ${response.status} ${response.statusText}${snippet ? ` - ${snippet}${tail}` : ''}`
       );
     }
   }

--- a/src/lib/devops.ts
+++ b/src/lib/devops.ts
@@ -1017,6 +1017,24 @@ export class AzureDevOpsService {
     }
   }
 
+  // Delete a work item — moves it to the DevOps Recycle Bin (reversible).
+  // Set destroy=true for a permanent, unrecoverable delete (admins only).
+  // Returns the API status code so callers can surface 401/403 specifically.
+  async deleteWorkItem(workItemId: number, destroy: boolean = false): Promise<void> {
+    const url = `${this.baseUrl}/_apis/wit/workitems/${workItemId}?destroy=${destroy ? 'true' : 'false'}&api-version=7.0`;
+    const response = await fetch(url, {
+      method: 'DELETE',
+      headers: this.headers,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => '');
+      throw new Error(
+        `Failed to delete work item: ${response.status} ${response.statusText}${errorText ? ' - ' + errorText : ''}`
+      );
+    }
+  }
+
   // Change work item type (e.g., Task → Bug)
   // Azure DevOps supports this via PATCH with System.WorkItemType in the JSON patch body
   async changeWorkItemType(

--- a/src/lib/devops.ts
+++ b/src/lib/devops.ts
@@ -259,6 +259,19 @@ export function workItemToTicket(workItem: DevOpsWorkItem, organization?: Organi
   };
 }
 
+// Thrown by AzureDevOpsService methods when the upstream DevOps API returns
+// a non-OK response. Callers can check `.status` to map to user-facing errors
+// (401/403 → permissions, 404 → not found, etc.) without parsing the message.
+export class DevOpsApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string
+  ) {
+    super(message);
+    this.name = 'DevOpsApiError';
+  }
+}
+
 export class AzureDevOpsService {
   private accessToken: string;
   private organization: string;
@@ -1018,8 +1031,10 @@ export class AzureDevOpsService {
   }
 
   // Delete a work item — moves it to the DevOps Recycle Bin (reversible).
-  // Set destroy=true for a permanent, unrecoverable delete (admins only).
-  // Returns the API status code so callers can surface 401/403 specifically.
+  // Pass destroy=true for a permanent, unrecoverable delete; whether the
+  // caller is allowed to do that is enforced by DevOps based on the user's
+  // role/PAT scope (no ZapDesk-side admin gate). Throws DevOpsApiError on
+  // failure so callers can branch on `.status` cleanly.
   async deleteWorkItem(workItemId: number, destroy: boolean = false): Promise<void> {
     const url = `${this.baseUrl}/_apis/wit/workitems/${workItemId}?destroy=${destroy ? 'true' : 'false'}&api-version=7.0`;
     const response = await fetch(url, {
@@ -1029,7 +1044,8 @@ export class AzureDevOpsService {
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => '');
-      throw new Error(
+      throw new DevOpsApiError(
+        response.status,
         `Failed to delete work item: ${response.status} ${response.statusText}${errorText ? ' - ' + errorText : ''}`
       );
     }


### PR DESCRIPTION
## Summary

Adds a **Delete** action to the ticket / work item detail dialog and the full-page detail view. Items are moved to the **Azure DevOps Recycle Bin** by default — reversible from DevOps if a user clicks delete by mistake. Permanent destroy is plumbed through the API but deliberately not exposed in the UI yet; that should be gated behind admin permissions in a follow-up.

## What's in the PR

- **`AzureDevOpsService.deleteWorkItem(id, destroy?)`** — `DELETE /_apis/wit/workitems/{id}?destroy=...&api-version=7.0`. Throws with the upstream status embedded so callers can map it.
- **`DELETE /api/devops/tickets/[id]`** route — auth + org-aware, accepts `?destroy=true` for permanent destroy. Maps upstream 401/403/404 to clean status codes so the client toast reads correctly (e.g. "You do not have permission to delete this work item in DevOps").
- **`WorkItemDetailDialog`** — red **Delete** button next to *Full View* / *DevOps*. `window.confirm` prompts with the item title and explains it's moving to Recycle Bin. Toast on success/failure, dialog closes, existing `onDeleted` prop fires so list owners can remove it from view.
- **`TicketDetail`** (full page) — new optional `onDelete` prop, identical confirmation + Delete button in the page header next to *View in DevOps*.
- **`/tickets/[id]/page.tsx`** — wires `onDelete` to call the API and route back to `/tickets` on success.
<img width="1595" height="978" alt="image" src="https://github.com/user-attachments/assets/f17db16a-b012-4183-adc3-f8d013fc1541" />

## Permission handling

The DevOps API returns 401 if the user's token is invalid, or 403 if they lack `Work Items (Read, write, & manage)`. The route maps both to user-friendly errors so the toast doesn't show raw upstream text. No client-side permission gate yet — that's a follow-up since the canonical permission model lives in DevOps.

Fixes #374

## Test plan

- [x] Open any ticket → click the new red **Delete** button → confirm → toast says \`Deleted #N\`, page redirects to `/tickets`, item is in DevOps Recycle Bin (not visible in the list)
- [x] Open a ticket via the dialog (Tickets list → click row) → Delete in dialog header → confirms, toasts, dialog closes, list refreshes without it
- [x] Cancelling the confirmation dialog leaves the ticket alone (no API call fires)
- [x] Restore the deleted item from DevOps Recycle Bin → it reappears in ZapDesk on next refresh
- [x] Delete a ticket while signed in as a user without Work Item delete permission in DevOps → toast reads "You do not have permission to delete this work item in DevOps"
- [x] Delete a non-existent / already-deleted id → toast reads "Work item not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)