### PR TITLE
fix: notify assigned agent when customer replies via email

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,27 +186,27 @@ When making changes:
 
 ## Environment Variables
 
-| Variable                                  | Description                                                  | Required                      |
-| ----------------------------------------- | ------------------------------------------------------------ | ----------------------------- |
-| `NEXTAUTH_URL`                            | Base URL of the application                                  | Yes                           |
-| `NEXTAUTH_SECRET`                         | Secret for NextAuth encryption                               | Yes                           |
-| `AZURE_AD_CLIENT_ID`                      | Azure AD application client ID                               | Yes                           |
-| `AZURE_AD_CLIENT_SECRET`                  | Azure AD application client secret                           | Yes                           |
-| `AZURE_AD_TENANT_ID`                      | Azure AD tenant ID (or 'common')                             | Yes                           |
-| `AZURE_DEVOPS_ORG`                        | Azure DevOps organization name                               | Yes                           |
-| `AZURE_DEVOPS_PAT`                        | Personal Access Token for service account                    | For email integration         |
-| `EMAIL_WEBHOOK_SECRET`                    | Shared secret for `/api/email/poll` and `/api/email/webhook` | For email integration         |
-| `MAIL_POLL_MAILBOX`                       | Mailbox ZapDesk polls for inbound email                      | For inbound email             |
-| `MAIL_FROM`                               | Sender address for outbound mail                             | For outbound email            |
-| `MAIL_FROM_NAME`                          | Display name for outbound mail                               | No (default: ZapDesk Support) |
-| `MAIL_TENANT_ID`                          | Tenant ID for the dedicated mail Azure AD app                | For email integration         |
-| `MAIL_CLIENT_ID`                          | Client ID for the dedicated mail Azure AD app                | For email integration         |
-| `MAIL_CLIENT_SECRET`                      | Client secret for the dedicated mail Azure AD app            | For email integration         |
-| `SUPPORT_TEAM_NOTIFY_EMAIL`               | Fallback recipient for customer-reply notifications when a ticket is unassigned | No |
-| `TEAM_THRESHOLD_NEEDS_ATTENTION_PENDING`  | Pending tickets threshold for "Needs Attention"              | No (default: 5)               |
-| `TEAM_THRESHOLD_NEEDS_ATTENTION_ASSIGNED` | Assigned tickets threshold for "Needs Attention"             | No (default: 15)              |
-| `TEAM_THRESHOLD_BEHIND_PENDING`           | Pending tickets threshold for "Behind"                       | No (default: 2)               |
-| `TEAM_THRESHOLD_BEHIND_ASSIGNED`          | Assigned tickets threshold for "Behind"                      | No (default: 10)              |
+| Variable                                  | Description                                                                     | Required                      |
+| ----------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------- |
+| `NEXTAUTH_URL`                            | Base URL of the application                                                     | Yes                           |
+| `NEXTAUTH_SECRET`                         | Secret for NextAuth encryption                                                  | Yes                           |
+| `AZURE_AD_CLIENT_ID`                      | Azure AD application client ID                                                  | Yes                           |
+| `AZURE_AD_CLIENT_SECRET`                  | Azure AD application client secret                                              | Yes                           |
+| `AZURE_AD_TENANT_ID`                      | Azure AD tenant ID (or 'common')                                                | Yes                           |
+| `AZURE_DEVOPS_ORG`                        | Azure DevOps organization name                                                  | Yes                           |
+| `AZURE_DEVOPS_PAT`                        | Personal Access Token for service account                                       | For email integration         |
+| `EMAIL_WEBHOOK_SECRET`                    | Shared secret for `/api/email/poll` and `/api/email/webhook`                    | For email integration         |
+| `MAIL_POLL_MAILBOX`                       | Mailbox ZapDesk polls for inbound email                                         | For inbound email             |
+| `MAIL_FROM`                               | Sender address for outbound mail                                                | For outbound email            |
+| `MAIL_FROM_NAME`                          | Display name for outbound mail                                                  | No (default: ZapDesk Support) |
+| `MAIL_TENANT_ID`                          | Tenant ID for the dedicated mail Azure AD app                                   | For email integration         |
+| `MAIL_CLIENT_ID`                          | Client ID for the dedicated mail Azure AD app                                   | For email integration         |
+| `MAIL_CLIENT_SECRET`                      | Client secret for the dedicated mail Azure AD app                               | For email integration         |
+| `SUPPORT_TEAM_NOTIFY_EMAIL`               | Fallback recipient for customer-reply notifications when a ticket is unassigned | No                            |
+| `TEAM_THRESHOLD_NEEDS_ATTENTION_PENDING`  | Pending tickets threshold for "Needs Attention"                                 | No (default: 5)               |
+| `TEAM_THRESHOLD_NEEDS_ATTENTION_ASSIGNED` | Assigned tickets threshold for "Needs Attention"                                | No (default: 15)              |
+| `TEAM_THRESHOLD_BEHIND_PENDING`           | Pending tickets threshold for "Behind"                                          | No (default: 2)               |
+| `TEAM_THRESHOLD_BEHIND_ASSIGNED`          | Assigned tickets threshold for "Behind"                                         | No (default: 10)              |
 
 ## Deployment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,7 @@ When making changes:
 | `MAIL_TENANT_ID`                          | Tenant ID for the dedicated mail Azure AD app                | For email integration         |
 | `MAIL_CLIENT_ID`                          | Client ID for the dedicated mail Azure AD app                | For email integration         |
 | `MAIL_CLIENT_SECRET`                      | Client secret for the dedicated mail Azure AD app            | For email integration         |
+| `SUPPORT_TEAM_NOTIFY_EMAIL`               | Fallback recipient for customer-reply notifications when a ticket is unassigned | No |
 | `TEAM_THRESHOLD_NEEDS_ATTENTION_PENDING`  | Pending tickets threshold for "Needs Attention"              | No (default: 5)               |
 | `TEAM_THRESHOLD_NEEDS_ATTENTION_ASSIGNED` | Assigned tickets threshold for "Needs Attention"             | No (default: 15)              |
 | `TEAM_THRESHOLD_BEHIND_PENDING`           | Pending tickets threshold for "Behind"                       | No (default: 2)               |

--- a/src/lib/email-ingest.ts
+++ b/src/lib/email-ingest.ts
@@ -8,7 +8,7 @@
  */
 
 import { getProjectFromEmail } from '@/lib/devops';
-import { sendTicketConfirmation } from '@/lib/email';
+import { sendCustomerReplyNotification, sendTicketConfirmation } from '@/lib/email';
 import { escapeHtml, renderEmailBody } from '@/lib/email-clean';
 
 const TICKET_REF_REGEX = /\[ZapDesk #(\d+)\]/;
@@ -104,20 +104,60 @@ async function handleThreadReply(
 ): Promise<IngestResult> {
   const devops = new AzureDevOpsServiceWithPAT(encodedPat);
   try {
+    const renderedBody = renderEmailBody(body);
     const commentHtml = `
 <div style="font-family: sans-serif;">
   <p><strong>Email reply from:</strong> ${escapeHtml(senderEmail)}</p>
   <hr/>
-  ${renderEmailBody(body)}
+  ${renderedBody}
 </div>`.trim();
 
-    await devops.addComment(ticketId, commentHtml);
+    const updatedWorkItem = await devops.addComment(ticketId, commentHtml);
     console.log(`Added email reply to ticket #${ticketId} from ${senderEmail}`);
+
+    notifyAgentOfReply(updatedWorkItem, ticketId, senderEmail, renderedBody);
+
     return { success: true, action: 'comment_added', ticketId };
   } catch (error) {
     console.error(`Failed to add comment to ticket #${ticketId}:`, error);
     return { success: false, status: 500, error: 'Failed to add comment to ticket' };
   }
+}
+
+interface WorkItemFieldsResponse {
+  fields?: {
+    'System.Title'?: string;
+    'System.AssignedTo'?: { uniqueName?: string; displayName?: string } | string;
+  };
+}
+
+function notifyAgentOfReply(
+  workItem: WorkItemFieldsResponse | null | undefined,
+  ticketId: number,
+  senderEmail: string,
+  renderedBodyHtml: string
+): void {
+  const fields = workItem?.fields ?? {};
+  const title = fields['System.Title'] || `Ticket #${ticketId}`;
+  const assigned = fields['System.AssignedTo'];
+  const assignedEmail = typeof assigned === 'object' && assigned ? assigned.uniqueName : undefined;
+  // Groups and team identities have a uniqueName like `[Project]\Team Name`
+  // which won't contain `@`. Treat anything that doesn't look like an email
+  // address as "no assignee" and fall back to the configured team address.
+  const recipient =
+    assignedEmail && assignedEmail.includes('@')
+      ? assignedEmail
+      : process.env.SUPPORT_TEAM_NOTIFY_EMAIL || '';
+  if (!recipient) {
+    console.log(
+      `[Notify] No agent assigned and SUPPORT_TEAM_NOTIFY_EMAIL not set — skipping notification for ticket #${ticketId}`
+    );
+    return;
+  }
+  // Fire-and-forget — must never block or fail the comment add.
+  sendCustomerReplyNotification(ticketId, title, recipient, senderEmail, renderedBodyHtml).catch(
+    () => {}
+  );
 }
 
 class AzureDevOpsServiceWithPAT {

--- a/src/lib/email-templates.ts
+++ b/src/lib/email-templates.ts
@@ -131,6 +131,26 @@ export function agentReplyTemplate(opts: {
   `);
 }
 
+export function customerReplyNotificationTemplate(opts: {
+  ticketId: number;
+  ticketSubject: string;
+  customerEmail: string;
+  replyContentHtml: string;
+}): string {
+  const ticketUrl = `${APP_URL}/tickets/${opts.ticketId}`;
+  return layoutWrapper(`
+    <p class="meta">New customer reply on ticket <strong>#${opts.ticketId}</strong></p>
+    <p class="meta"><strong>Subject:</strong> ${opts.ticketSubject}</p>
+    <p class="meta"><strong>From:</strong> ${opts.customerEmail}</p>
+    <div class="content">
+      ${opts.replyContentHtml}
+    </div>
+    <p style="text-align: center; margin-top: 24px;">
+      <a href="${ticketUrl}" class="btn">View Ticket #${opts.ticketId}</a>
+    </p>
+  `);
+}
+
 export function statusChangeTemplate(opts: {
   ticketId: number;
   subject: string;

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -11,6 +11,7 @@ import {
   ticketConfirmationTemplate,
   agentReplyTemplate,
   statusChangeTemplate,
+  customerReplyNotificationTemplate,
   type HistoryEntry,
 } from './email-templates';
 
@@ -272,6 +273,45 @@ export async function sendStatusChangeNotification(
   } catch (error) {
     console.error(
       `[Email] Failed to send status change notification for ticket #${ticketId}:`,
+      error
+    );
+  }
+}
+
+/**
+ * Notify the assigned agent (or fallback team) that a customer replied to a
+ * ticket via email. Sent on a fresh thread — no In-Reply-To pointing at the
+ * customer's email — so the internal conversation stays separate from the
+ * customer-facing one.
+ */
+export async function sendCustomerReplyNotification(
+  ticketId: number,
+  ticketSubject: string,
+  agentEmail: string,
+  customerEmail: string,
+  replyContentHtml: string
+): Promise<void> {
+  if (!isEmailConfigured()) return;
+  try {
+    const messageId = generateMessageId(ticketId, 'agent-notify');
+    const html = customerReplyNotificationTemplate({
+      ticketId,
+      ticketSubject,
+      customerEmail,
+      replyContentHtml,
+    });
+    await sendViaGraph({
+      to: agentEmail,
+      subject: `[ZapDesk #${ticketId}] New customer reply — "${ticketSubject}"`,
+      html,
+      messageId,
+    });
+    console.log(
+      `[Email] Customer reply notification sent for ticket #${ticketId} to ${agentEmail}`
+    );
+  } catch (error) {
+    console.error(
+      `[Email] Failed to send customer reply notification for ticket #${ticketId}:`,
       error
     );
   }


### PR DESCRIPTION
## Summary

When the email-poll path adds a comment to an existing ticket (`action: comment_added`), send an internal notification to the assigned agent so they don't have to discover the reply by refreshing the queue.

- Recipient resolution: `System.AssignedTo.uniqueName` if it looks like an email, otherwise the new `SUPPORT_TEAM_NOTIFY_EMAIL` env var, otherwise log and skip.
- Notification is **fire-and-forget** — wrapped so any mail send failure cannot block or fail the comment add.
- Only triggers from `handleThreadReply`. Agent-UI comments use a different code path and never produce a notification.
- Internal email goes on its own thread (no `In-Reply-To` header pointing at the customer's email), so it doesn't pollute the customer-facing conversation.
- Same `renderEmailBody` pipeline as the on-ticket comment, so signature stripping is consistent between the two views the agent sees.

## Fixes

Fixes #360

## What this covers

| Scenario | Before | After |
|---|---|---|
| Customer replies to a `[ZapDesk #N]`-tagged email; ticket has an assignee | Comment added silently — agent only sees it on next page refresh | Comment added; assignee receives `[ZapDesk #N] New customer reply — "<title>"` in their inbox with a `View Ticket #N` button |
| Customer replies; ticket is unassigned | Same silent comment | If `SUPPORT_TEAM_NOTIFY_EMAIL` is set, the team address gets the notification. Otherwise a `[Notify] … skipping` log line is emitted and the comment add still succeeds. |
| Assignee is a DevOps **team / group** identity (no `@` in `uniqueName`) | n/a (no notification existed) | Treated as no individual assignee — falls through to `SUPPORT_TEAM_NOTIFY_EMAIL`. |
| Mail send fails (PAT issue, Graph 5xx, network) | n/a | Logged with ticket id; comment add still succeeds, poll still returns `action: "comment_added"`. |
| Comment added by an agent in the ZapDesk UI | n/a | Unchanged — the UI uses a different DevOps code path; this notification never fires for agent-originated comments. |

## Files changed

- `src/lib/email-ingest.ts` — capture the work item returned by `addComment`, extract `System.AssignedTo` + `System.Title`, fire-and-forget `sendCustomerReplyNotification` call. Adds a `WorkItemFieldsResponse` type for the PATCH response shape and a `notifyAgentOfReply` helper.
- `src/lib/email.ts` — new `sendCustomerReplyNotification` exported. Uses `generateMessageId(id, 'agent-notify')` and deliberately omits `inReplyTo` so the agent thread is independent of the customer thread.
- `src/lib/email-templates.ts` — new `customerReplyNotificationTemplate` reusing the existing layout/branding.
- `CLAUDE.md` — documents the new optional `SUPPORT_TEAM_NOTIFY_EMAIL` env var.

## New env var

| Variable | Purpose | Required |
|---|---|---|
| `SUPPORT_TEAM_NOTIFY_EMAIL` | Fallback recipient when a ticket has no individual assignee. Set to a distribution list like `support@your-domain.com`. | No (without it, unassigned tickets just log a skip line) |

## Test plan

### Local manual (verified)

1. `bun run dev`, ensure `MAIL_*`, `AZURE_DEVOPS_PAT`, `EMAIL_WEBHOOK_SECRET`, `MAIL_POLL_MAILBOX` are set.
2. Create or pick a ticket the PAT can write to. Assign it to yourself in DevOps.
3. From a customer-domain address, send an email to the polled mailbox with `Subject: [ZapDesk #N] testing notification`.
4. Trigger the poll:
   ```powershell
   Invoke-RestMethod -Method Post -Uri http://localhost:3000/api/email/poll -Headers @{ "x-webhook-secret" = "<EMAIL_WEBHOOK_SECRET>" } | ConvertTo-Json -Depth 6
   ```
5. **Expected response:** `fetched: 1, ingested: 1`, `results[0].result.action: "comment_added"`, `ticketId: N`.
6. **Expected dev-server log:**
   ```
   Added email reply to ticket #N from <customer>
   [Email] Customer reply notification sent for ticket #N to <assignee>
   ```
7. **Expected assignee inbox:** new email subject `[ZapDesk #N] New customer reply — "<original ticket title>"`, body shows `Subject:`, `From:`, the customer reply (signature-stripped) and a green `View Ticket #N` button.
8. **Confirm thread isolation:** the notification email arrives in a *different mail thread* than the customer-facing emails for the same ticket.

### Fallback path (verified earlier in the same session)

9. Un-assign the ticket. Re-poll a fresh `[ZapDesk #N]` email.
10. **With `SUPPORT_TEAM_NOTIFY_EMAIL` set:** notification arrives at the team address.
11. **Without it set:** dev-server logs `[Notify] No agent assigned and SUPPORT_TEAM_NOTIFY_EMAIL not set — skipping notification for ticket #N`. Comment is still added — `action: "comment_added"` in the response.

### Failure path (graceful degradation)

12. Temporarily break `MAIL_CLIENT_SECRET`, send a `[ZapDesk #N]` email, re-poll.
13. **Expected:** poll response still `action: "comment_added"`; comment still on the ticket; dev-server logs `[Email] Failed to send customer reply notification for ticket #N: ...`. Restore secret afterwards.

### UI-originated comments

14. Add a comment from the ZapDesk ticket UI.
15. **Expected:** **no** `[Notify]` or `[Email] Customer reply notification` log line. The notification path is scoped strictly to inbound email replies.

### Automated checks

- [x] `bun run typecheck` — passes
- [x] `bun run lint` — passes (4 pre-existing warnings, unrelated)
- [x] `bunx prettier --check` on changed files — passes

## Out of scope

- Microsoft Teams / Slack / push notification channels (issue marks as future).
- In-app banner / unread badge.
- Per-user notification opt-out (issue accepts a global setting for v1).
- Watchers / CC list (issue notes "future, if a watcher list is introduced").
- Encrypted / S/MIME inbound mail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
