### PR TITLE
fix: hide work items with Removed state from Kanban board (#277)

### DIFF
--- a/src/app/api/devops/standup/route.ts
+++ b/src/app/api/devops/standup/route.ts
@@ -238,13 +238,14 @@ export async function GET(request: NextRequest) {
 
     const displayColumnNames = new Set(displayColumns.map((c) => c.name));
 
-    // Map non-display states to the fallback column for their category
+    // Map non-display states to the fallback column for their category.
+    // 'Removed' is omitted because getStandupData filters those out before
+    // we get here (issue #277).
     const categoryFallback: Record<string, string> = {
       Proposed: 'New',
       InProgress: 'Active',
       Resolved: 'Resolved',
       Completed: 'Closed',
-      Removed: 'Closed',
     };
 
     // Resolve any DevOps state to one of the 6 display columns

--- a/src/lib/devops.ts
+++ b/src/lib/devops.ts
@@ -2426,11 +2426,14 @@ export class AzureDevOpsService {
     nextDay.setDate(nextDay.getDate() + 1);
     const nextDayStr = nextDay.toISOString().split('T')[0];
 
-    // Build state lists dynamically from categories
+    // Build state lists dynamically from categories.
+    // 'Removed' states are intentionally excluded — removed work items are
+    // hidden from the Kanban board (issue #277).
     const doneStates: string[] = [];
     const activeStates: string[] = [];
     for (const [state, category] of Object.entries(stateCategories)) {
-      if (category === 'Resolved' || category === 'Completed' || category === 'Removed') {
+      if (category === 'Removed') continue;
+      if (category === 'Resolved' || category === 'Completed') {
         doneStates.push(state);
       } else {
         activeStates.push(state);


### PR DESCRIPTION
## Summary
- The Kanban board was bucketing `Removed`-category states into the **Closed** column. Filter them out at the source so removed work items never appear on the board.
- `getStandupData` skips `Removed` when building the state lists used in the standup WIQL queries.
- Drop the now-unreachable `Removed: 'Closed'` fallback in the standup route.

Fixes #277.

## Test plan
- [ ] Open `/kanban` against an org with a project that has a `Removed` state — confirm no removed items appear in any column.
- [ ] Confirm Closed column still shows items in `Resolved`/`Completed` categories from the last 7 days.
- [ ] Confirm "Group By: Person" view also excludes removed items.
- [ ] Confirm the existing **Removed tickets** sidebar link (which uses a different endpoint) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)