### PR TITLE
feat: highlight @mentions in dialog comments (#138)

### DIFF
--- a/src/components/tickets/CommentSection.tsx
+++ b/src/components/tickets/CommentSection.tsx
@@ -5,6 +5,7 @@ import { format } from 'date-fns';
 import { Send, Zap, Paperclip, Loader2 } from 'lucide-react';
 import Avatar from '@/components/common/Avatar';
 import MentionInput from '@/components/common/MentionInput';
+import { highlightMentions } from '@/lib/mentions';
 import type { TicketComment, User, Attachment } from '@/types';
 
 interface CommentSectionProps {
@@ -158,7 +159,7 @@ export default function CommentSection({
                   <div
                     className={`user-content ${compact ? 'prose prose-sm prose-invert max-w-none text-sm' : 'text-sm'}`}
                     style={{ color: 'var(--text-secondary)' }}
-                    dangerouslySetInnerHTML={{ __html: comment.content }}
+                    dangerouslySetInnerHTML={{ __html: highlightMentions(comment.content) }}
                   />
                 </div>
               </div>
@@ -198,8 +199,8 @@ export default function CommentSection({
               onPaste={onUploadAttachment ? handlePaste : undefined}
               placeholder={
                 compact
-                  ? 'Add a comment... Paste images with Ctrl+V'
-                  : 'Type your reply... Paste images with Ctrl+V'
+                  ? 'Add a comment... Use @ to mention. Paste images with Ctrl+V'
+                  : 'Type your reply... Use @ to mention. Paste images with Ctrl+V'
               }
               className={`input w-full resize-none ${compact ? 'min-h-[60px] text-sm' : 'min-h-[100px]'}`}
               disabled={isSubmitting || isPastingImage}


### PR DESCRIPTION
## Summary
- The full ticket page (`TicketDetail`) already styles `@mentions` via `highlightMentions`, but the work-item dialog's `CommentSection` was rendering `comment.content` raw — so the same dropdown-inserted mentions stayed plain text in the dialog.
- Pipe `comment.content` through `highlightMentions` in `CommentSection` so the dialog matches the full page.
- Tweak the comment placeholder text to advertise the `@` trigger, matching the hint already in `TicketDetail`.

The autocomplete itself (the `MentionInput` component, `/api/devops/users` endpoint, debouncing, keyboard nav, plain-text storage) was already in place — this PR closes the visible gap so #138's "highlighted in the comment" behavior is consistent everywhere comments render.

Fixes #138.

## Test plan
- [x] Open a ticket via the Kanban / Tickets list dialog (work-item dialog), type `@`, pick a user from the dropdown, submit. Verify the rendered comment shows the mention highlighted in green.
- [x] Open the same ticket on the full `/tickets/[id]` page — confirm highlighting still works there (no regression).
- [x] Reload the dialog and verify previously-stored mention comments are highlighted on initial render.
- [x] Confirm the placeholder text reads "Use @ to mention" in both compact and full reply boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)