### PR TITLE
feat: show remaining effort on kanban cards

### DIFF
--- a/src/app/api/devops/standup/route.ts
+++ b/src/app/api/devops/standup/route.ts
@@ -142,6 +142,7 @@ function mapWorkItemToStandupItem(
 ): StandupWorkItem {
   const fields = wi.fields;
   const assignedTo = fields['System.AssignedTo'];
+  const remainingWork = fields['Microsoft.VSTS.Scheduling.RemainingWork'] as number | undefined;
   return {
     id: wi.id,
     title: fields['System.Title'],
@@ -167,6 +168,7 @@ function mapWorkItemToStandupItem(
         .map((t: string) => t.trim())
         .filter(Boolean) || [],
     iterationPath: (fields['System.IterationPath'] as string) || undefined,
+    remainingWork: typeof remainingWork === 'number' ? remainingWork : undefined,
   };
 }
 

--- a/src/components/standup/StandupKanbanCard.tsx
+++ b/src/components/standup/StandupKanbanCard.tsx
@@ -35,6 +35,13 @@ export default function StandupKanbanCard({ item, isDragging, onClick }: Standup
 
   const typeColor = typeColors[item.workItemType] || 'var(--text-muted)';
 
+  const hasRemainingWork = typeof item.remainingWork === 'number' && item.remainingWork > 0;
+  const remainingLabel = hasRemainingWork
+    ? item.remainingWork! < 1
+      ? `${item.remainingWork!.toFixed(1)}h`
+      : `${Math.round(item.remainingWork!)}h`
+    : null;
+
   const cardBody = (
     <>
       <div className="mb-1.5 flex items-center justify-between gap-2">
@@ -50,7 +57,18 @@ export default function StandupKanbanCard({ item, isDragging, onClick }: Standup
           </span>
           <span className="text-xs text-[var(--text-muted)]">#{item.id}</span>
         </div>
-        <PriorityIndicator priority={item.priority} />
+        <div className="flex items-center gap-1.5">
+          {remainingLabel && (
+            <span
+              className="rounded bg-[var(--surface-hover)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--text-muted)]"
+              aria-label={`Remaining effort: ${remainingLabel}`}
+              title={`Remaining effort: ${remainingLabel}`}
+            >
+              {remainingLabel}
+            </span>
+          )}
+          <PriorityIndicator priority={item.priority} />
+        </div>
       </div>
 
       <h4 className="mb-2 line-clamp-2 text-sm font-medium text-[var(--text-primary)]">

--- a/src/components/standup/StandupKanbanCard.tsx
+++ b/src/components/standup/StandupKanbanCard.tsx
@@ -37,9 +37,9 @@ export default function StandupKanbanCard({ item, isDragging, onClick }: Standup
 
   const hasRemainingWork = typeof item.remainingWork === 'number' && item.remainingWork > 0;
   const remainingLabel = hasRemainingWork
-    ? item.remainingWork! < 1
-      ? `${item.remainingWork!.toFixed(1)}h`
-      : `${Math.round(item.remainingWork!)}h`
+    ? Number.isInteger(item.remainingWork)
+      ? `${item.remainingWork}h`
+      : `${item.remainingWork!.toFixed(1)}h`
     : null;
 
   const cardBody = (

--- a/src/lib/devops.ts
+++ b/src/lib/devops.ts
@@ -2541,6 +2541,7 @@ export class AzureDevOpsService {
       'System.Tags',
       'System.IterationPath',
       'Microsoft.VSTS.Common.Priority',
+      'Microsoft.VSTS.Scheduling.RemainingWork',
     ].join(',');
 
     for (let i = 0; i < workItemIds.length; i += batchSize) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -538,6 +538,7 @@ export interface StandupWorkItem {
   devOpsUrl: string;
   tags: string[];
   iterationPath?: string;
+  remainingWork?: number;
 }
 
 /** A column definition pulled from DevOps state configuration */


### PR DESCRIPTION
## Summary
- Adds the `Microsoft.VSTS.Scheduling.RemainingWork` field to the standup work item batch fetch
- Exposes `remainingWork` on `StandupWorkItem` and maps it in the standup API route
- Renders a small remaining-effort pill (e.g. `4h`) next to the priority indicator on each kanban card; cards with no remaining work set are unchanged
<img width="1265" height="714" alt="image" src="https://github.com/user-attachments/assets/3bc9a57b-ede7-49bb-89a6-7a5a4abfb0cb" />


Fixes #381

## Test plan
- [x] Open `/kanban` and confirm cards with a Remaining Work value display the hours pill (e.g. `4h`, `0.5h`)
- [x] Confirm cards with no Remaining Work set render exactly as before
- [x] Group by Person and Project — pill renders in both modes
- [x] Hover the pill — tooltip reads "Remaining effort: Xh"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
