### PR TITLE
fix: allow LNURL callback host to differ from Lightning address host (#387)

### DIFF
--- a/src/components/tickets/ZapDialog.tsx
+++ b/src/components/tickets/ZapDialog.tsx
@@ -93,17 +93,14 @@ function ZapDialogContent({
         throw new Error('No LNURL callback found in response');
       }
 
-      // Validate callback URL for security:
-      // - Must use HTTPS
-      // - Should match the original domain to prevent redirect attacks
+      // Validate callback URL: must use HTTPS.
+      // The LNURL spec does not require the callback host to match the
+      // .well-known host, and legitimate providers (e.g. Wallet of Satoshi
+      // serves callbacks from livingroomofsatoshi.com) routinely split them.
       try {
         const callbackUrlObj = new URL(meta.callback);
         if (callbackUrlObj.protocol !== 'https:') {
           throw new Error('Callback URL must use HTTPS');
-        }
-        // Allow same domain or subdomains
-        if (!callbackUrlObj.hostname.endsWith(domain) && callbackUrlObj.hostname !== domain) {
-          throw new Error('Callback URL domain does not match Lightning address domain');
         }
       } catch (urlErr) {
         if (urlErr instanceof Error && urlErr.message.includes('Invalid URL')) {


### PR DESCRIPTION
## Summary

- Fixes #387 — the Zap dialog refused to fetch invoices for Wallet of Satoshi addresses (and any other provider whose LNURL callback URL is served from a host different to the `.well-known/lnurlp` host), showing "Callback URL domain does not match Lightning address domain" instead of a QR code.
- The LNURL spec does not require the callback host to match the well-known host; WoS for example serves callbacks from `livingroomofsatoshi.com`. Drop the cross-domain rejection, keep the HTTPS requirement and the existing BOLT11 validation downstream.

## Test plan

- [x] Open a ticket whose assignee has a `@walletofsatoshi.com` Lightning address (e.g. Ticket #5911) → Zap dialog renders a QR code instead of the error.
- [x] Confirm zaps to a same-domain provider (e.g. Alby `@getalby.com`) still work.
- [x] Confirm an `http://` callback URL is still rejected.
- [x] `bun run check` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)