### PR TITLE
fix: post zap comment from WorkItemDetailDialog (#385)

### DIFF
--- a/src/components/tickets/WorkItemDetailDialog.tsx
+++ b/src/components/tickets/WorkItemDetailDialog.tsx
@@ -138,6 +138,20 @@ export default function WorkItemDetailDialog({
     [workItem, fetchComments, fetchDevOps, hasOrganization]
   );
 
+  const handleZapSent = useCallback(
+    async (amount: number) => {
+      if (!workItem) return;
+      const assigneeName = workItem.assignee?.displayName || 'the agent';
+      const zapMessage = `⚡ Sent a ${amount.toLocaleString()} sat zap to ${assigneeName} for great support!`;
+      try {
+        await handleAddComment(zapMessage);
+      } catch (err) {
+        console.error('[WorkItemDetailDialog] Failed to post zap comment:', err);
+      }
+    },
+    [workItem, handleAddComment]
+  );
+
   const handleUploadAttachment = useCallback(
     async (file: File): Promise<Attachment> => {
       if (!workItem) throw new Error('No work item');
@@ -353,6 +367,7 @@ export default function WorkItemDetailDialog({
           onAddComment={handleAddComment}
           onUploadAttachment={handleUploadAttachment}
           onUpdate={onUpdate ? handleUpdate : undefined}
+          onZapSent={handleZapSent}
           showEffortTracking
           compact
         />


### PR DESCRIPTION
## Summary

- Fixes #385 — zaps sent from the work-item dialog (e.g. Kanban → ticket dialog) were never recorded on the work item.
- `WorkItemDetailContent.handleZapSent` only forwarded an `onZapSent` prop, and `WorkItemDetailDialog` never wired one up. Add `handleZapSent` on the dialog that posts a zap comment through the existing `handleAddComment` flow, mirroring `TicketDetail.handleZapSent`, and pass it through.

## Test plan

- [x] Open a ticket via the Kanban board work-item dialog (e.g. Ticket #5908). Send a zap. Confirm a ⚡ comment is added to the work item in both ZapDesk and Azure DevOps.
- [x] Confirm zaps from the full ticket page (`TicketDetail`) still post a comment as before.
- [x] If the assignee is unset, the comment falls back to "the agent" rather than throwing.
- [x] `bun run check` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)