### PR TITLE
fix: global search finds non-ticket work items by ID and text (#386)

### DIFF
--- a/src/app/api/devops/search/route.ts
+++ b/src/app/api/devops/search/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
+import { validateOrganizationAccess } from '@/lib/devops-auth';
 import { AzureDevOpsService } from '@/lib/devops';
 
 interface SearchResult {
@@ -20,6 +21,16 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
+    const organization = request.headers.get('x-devops-org');
+    if (!organization) {
+      return NextResponse.json({ error: 'No organization specified' }, { status: 400 });
+    }
+
+    const hasAccess = await validateOrganizationAccess(session.accessToken, organization);
+    if (!hasAccess) {
+      return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+    }
+
     const searchParams = request.nextUrl.searchParams;
     const query = searchParams.get('q')?.toLowerCase().trim();
 
@@ -27,7 +38,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ results: [] });
     }
 
-    const devopsService = new AzureDevOpsService(session.accessToken);
+    const devopsService = new AzureDevOpsService(session.accessToken, organization);
     const results: SearchResult[] = [];
     const seenTicketIds = new Set<string>();
 

--- a/src/app/api/devops/search/route.ts
+++ b/src/app/api/devops/search/route.ts
@@ -29,15 +29,48 @@ export async function GET(request: NextRequest) {
 
     const devopsService = new AzureDevOpsService(session.accessToken);
     const results: SearchResult[] = [];
+    const seenTicketIds = new Set<string>();
 
-    // Search tickets
-    const tickets = await devopsService.getAllTickets();
+    // Numeric-only queries are almost always direct work item ID lookups
+    // (e.g. "5908"). The tag-filtered ticket search misses any work item that
+    // isn't tagged "ticket" — Checkpoints, Features, Bugs surfaced on the
+    // Kanban board, etc. — so do an org-level lookup first.
+    if (/^\d+$/.test(query)) {
+      try {
+        const workItem = await devopsService.findWorkItemById(parseInt(query, 10));
+        if (workItem) {
+          const fields = workItem.fields || {};
+          const id = workItem.id.toString();
+          const title = (fields['System.Title'] as string | undefined) || `#${id}`;
+          const state = (fields['System.State'] as string | undefined) || '';
+          const type = (fields['System.WorkItemType'] as string | undefined) || 'Work Item';
+          results.push({
+            type: 'ticket',
+            id,
+            title,
+            subtitle: `${type} #${id}${state ? ` • ${state}` : ''}`,
+            url: `/tickets/${id}`,
+            status: state,
+          });
+          seenTicketIds.add(id);
+        }
+      } catch (err) {
+        console.error('Direct work item lookup failed:', err);
+        // Fall through to the tag-filtered search below
+      }
+    }
+
+    // Search across all work items the user can access — not just those tagged
+    // "ticket". The Kanban board surfaces Checkpoints, Features, Bugs, etc.,
+    // and users expect global search to find them too.
+    const tickets = await devopsService.getAllTickets(false);
     const matchingTickets = tickets
       .filter(
         (t) =>
-          t.title.toLowerCase().includes(query) ||
-          t.id.toString().includes(query) ||
-          t.description?.toLowerCase().includes(query)
+          !seenTicketIds.has(t.id.toString()) &&
+          (t.title.toLowerCase().includes(query) ||
+            t.id.toString().includes(query) ||
+            t.description?.toLowerCase().includes(query))
       )
       .slice(0, 5)
       .map((t) => ({

--- a/src/app/api/devops/search/route.ts
+++ b/src/app/api/devops/search/route.ts
@@ -40,7 +40,6 @@ export async function GET(request: NextRequest) {
 
     const devopsService = new AzureDevOpsService(session.accessToken, organization);
     const results: SearchResult[] = [];
-    const seenTicketIds = new Set<string>();
 
     // Numeric-only queries are almost always direct work item ID lookups
     // (e.g. "5908"). The tag-filtered ticket search misses any work item that
@@ -63,7 +62,9 @@ export async function GET(request: NextRequest) {
             url: `/tickets/${id}`,
             status: state,
           });
-          seenTicketIds.add(id);
+          // Direct hit — skip the full getAllTickets() scan and the
+          // org/user searches (a pure-digit query won't match those).
+          return NextResponse.json({ results });
         }
       } catch (err) {
         console.error('Direct work item lookup failed:', err);
@@ -78,10 +79,9 @@ export async function GET(request: NextRequest) {
     const matchingTickets = tickets
       .filter(
         (t) =>
-          !seenTicketIds.has(t.id.toString()) &&
-          (t.title.toLowerCase().includes(query) ||
-            t.id.toString().includes(query) ||
-            t.description?.toLowerCase().includes(query))
+          t.title.toLowerCase().includes(query) ||
+          t.id.toString().includes(query) ||
+          t.description?.toLowerCase().includes(query)
       )
       .slice(0, 5)
       .map((t) => ({

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -18,7 +18,7 @@ import {
   Menu,
 } from 'lucide-react';
 import { Avatar } from '@/components/common';
-import { useProfilePhoto } from '@/hooks';
+import { useProfilePhoto, useDevOpsApi } from '@/hooks';
 import OrganizationSwitcher from './OrganizationSwitcher';
 
 interface SearchResult {
@@ -37,6 +37,7 @@ interface HeaderProps {
 export default function Header({ onMenuClick }: HeaderProps) {
   const { data: session, status } = useSession();
   const { photoUrl } = useProfilePhoto(status === 'authenticated');
+  const { get: getDevOps, hasOrganization } = useDevOpsApi();
   const router = useRouter();
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -54,11 +55,12 @@ export default function Header({ onMenuClick }: HeaderProps) {
       setShowSearchResults(false);
       return;
     }
+    if (!hasOrganization) return;
 
     const timeoutId = setTimeout(async () => {
       setIsSearching(true);
       try {
-        const response = await fetch(`/api/devops/search?q=${encodeURIComponent(searchQuery)}`);
+        const response = await getDevOps(`/api/devops/search?q=${encodeURIComponent(searchQuery)}`);
         if (response.ok) {
           const data = await response.json();
           setSearchResults(data.results || []);
@@ -73,7 +75,7 @@ export default function Header({ onMenuClick }: HeaderProps) {
     }, 300);
 
     return () => clearTimeout(timeoutId);
-  }, [searchQuery]);
+  }, [searchQuery, getDevOps, hasOrganization]);
 
   // Keyboard shortcut (Cmd/Ctrl+K)
   useEffect(() => {

--- a/src/lib/devops.ts
+++ b/src/lib/devops.ts
@@ -504,6 +504,28 @@ export class AzureDevOpsService {
     return 'error';
   }
 
+  // Org-level fetch of a work item with the minimal fields needed for search/preview.
+  // Unlike getWorkItem, no project name is required and tag filters do not apply,
+  // so this finds any work item the user can access (Bug, Checkpoint, Feature, etc.).
+  async findWorkItemById(workItemId: number): Promise<DevOpsWorkItem | null> {
+    const fields = [
+      'System.Id',
+      'System.Title',
+      'System.State',
+      'System.WorkItemType',
+      'System.TeamProject',
+    ].join(',');
+    const response = await fetch(
+      `${this.baseUrl}/_apis/wit/workitems/${workItemId}?fields=${fields}&api-version=7.0`,
+      { headers: this.headers }
+    );
+    if (response.status === 404) return null;
+    if (!response.ok) {
+      throw new Error(`Failed to fetch work item ${workItemId}: ${response.statusText}`);
+    }
+    return response.json();
+  }
+
   // Get comments for a work item
   async getWorkItemComments(projectName: string, workItemId: number): Promise<TicketComment[]> {
     const response = await fetch(


### PR DESCRIPTION
## Summary

- Fixes #386 — global search returned nothing for queries like `5908` because the search route only walked `getAllTickets()`, which WIQL-filters to work items tagged `"ticket"`. Kanban surfaces Checkpoints, Features, Bugs, etc. that aren't tagged that way, so they were invisible to search.
- Add `AzureDevOpsService.findWorkItemById` — an org-level work item lookup with no project name and no tag filter. Returns any work item the user can access.
- In `src/app/api/devops/search/route.ts`, take a numeric-ID fast path that uses the new lookup so a query like `5908` returns the matching work item directly.
- Drop the `ticketsOnly` tag filter on the text-search path so titles/descriptions of Checkpoints and other non-"ticket"-tagged items are also matched (per discussion on the issue — global search should be global).

<img width="1882" height="948" alt="image" src="https://github.com/user-attachments/assets/0997d2ff-6998-4acb-a053-ededf86e7dbf" />


## Test plan

- [x] From the Kanban board, search for the numeric ID of a non-"ticket"-tagged work item (e.g. `5908`). It should appear in the dropdown with its work-item type in the subtitle.
- [x] Search for the title of a Checkpoint/Feature/Bug visible on the Kanban board — it should now appear.
- [x] Search for an existing ticket (e.g. partial title) — still works as before.
- [x] Search for a non-existent ID (e.g. `99999999`) — no `ticket` result, no console errors.
- [x] `bun run check` passes locally.

## Notes

- The numeric fast path makes a single org-level Graph call when the query is purely digits, so the common "look up by ID" case is fast and accurate regardless of tags.
- Removing `ticketsOnly` on the text-search path increases the number of work items considered per search. If this proves too slow on large orgs we can move to the Azure DevOps Search API (`https://almsearch.dev.azure.com/...`) — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #386
