### PR TITLE
fix: show Customer Response on Question work item dialog

### DIFF
--- a/src/components/tickets/WorkItemDetailContent.tsx
+++ b/src/components/tickets/WorkItemDetailContent.tsx
@@ -442,6 +442,20 @@ export default function WorkItemDetailContent({
         </div>
       )}
 
+      {/* Customer Response — Question work items only (issue #398) */}
+      {workItem.workItemType === 'Question' && workItem.customerResponse && (
+        <div className="card mt-4 p-4">
+          <h3 className="mb-2 text-sm font-medium" style={{ color: 'var(--text-muted)' }}>
+            Customer Response
+          </h3>
+          <div
+            className="prose prose-sm prose-invert user-content max-w-none"
+            style={{ color: 'var(--text-secondary)' }}
+            dangerouslySetInnerHTML={{ __html: workItem.customerResponse }}
+          />
+        </div>
+      )}
+
       {/* Resolution (editable) - only for work item types that support it */}
       {showResolution && <ResolutionField workItem={workItem} onUpdate={onUpdate} />}
       {showMitigation && <MitigationField workItem={workItem} onUpdate={onUpdate} />}

--- a/src/lib/devops.ts
+++ b/src/lib/devops.ts
@@ -463,6 +463,7 @@ export class AzureDevOpsService {
         'Microsoft.VSTS.Common.Resolution',
         'Microsoft.VSTS.TCM.ReproSteps',
         'Microsoft.VSTS.TCM.SystemInfo',
+        'Custom.CustomerResponse',
       ].join(',');
       const workItemsResponse = await fetch(
         `${this.baseUrl}/_apis/wit/workitems?ids=${batch.join(',')}&fields=${fields}&api-version=7.0`,

--- a/src/lib/devops.ts
+++ b/src/lib/devops.ts
@@ -219,6 +219,7 @@ export function ticketToWorkItem(ticket: Ticket): WorkItem {
     resolution: ticket.resolution,
     mitigation: ticket.mitigation,
     resolvedReason: ticket.resolvedReason,
+    customerResponse: ticket.customerResponse,
     requester: ticket.requester,
     organization: ticket.organization,
   };
@@ -237,6 +238,7 @@ export function workItemToTicket(workItem: DevOpsWorkItem, organization?: Organi
     resolution: readResolutionField(fields),
     mitigation: readMitigationField(fields),
     resolvedReason: (fields['Microsoft.VSTS.Common.ResolvedReason'] as string) || undefined,
+    customerResponse: (fields['Custom.CustomerResponse'] as string) || undefined,
     status: mapStateToStatus(fields['System.State']),
     devOpsState: fields['System.State'], // Preserve original DevOps state
     workItemType: fields['System.WorkItemType'], // Azure DevOps work item type

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -167,6 +167,8 @@ export interface Ticket {
   project: string;
   comments: TicketComment[];
   attachments?: Attachment[];
+  // Customer's response on a Question work item (Custom.CustomerResponse)
+  customerResponse?: string;
 }
 
 export interface TicketComment {
@@ -494,6 +496,8 @@ export interface WorkItem {
   resolution?: string;
   mitigation?: string;
   resolvedReason?: string;
+  // Customer's response on a Question work item (Custom.CustomerResponse)
+  customerResponse?: string;
   // Optional ticket-specific fields (populated when item is a ticket)
   requester?: Customer;
   organization?: Organization;


### PR DESCRIPTION
## Summary

- Reads \`Custom.CustomerResponse\` in \`workItemToTicket\` and carries it through \`ticketToWorkItem\` to the dialog.
- Adds \`customerResponse?: string\` to the \`Ticket\` and \`WorkItem\` types.
- Renders a new \"Customer Response\" section in \`WorkItemDetailContent\`, between Description and resolution / effort cards. Only shown when \`workItemType === 'Question'\` and the field has content, so other types are unaffected.
- HTML is preserved (same \`dangerouslySetInnerHTML\` treatment as Description), so rich-text formatting from DevOps shows correctly.

<img width="1186" height="791" alt="image" src="https://github.com/user-attachments/assets/c9d5b2b1-07a7-400b-b696-3969afb740c2" />


Fixes #398

## Test plan

- [x] Open a Question card from the Kanban board — \"Customer Response\" appears between Description and Comments.
- [x] Open a non-Question card (Bug / Task / Enhancement / Issue / Risk) — no \"Customer Response\" section.
- [x] Open a Question with the Customer Response field empty — section is hidden, not rendered as empty.
- [x] Rich-text formatting in the field (lists, bold, etc.) renders properly.
- [x] \`bun run check\` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)