### PR TITLE
chore: bump version to v0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapdesk",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3102",


### PR DESCRIPTION
Bumps version `0.9.0` -> `0.10.0` for the production release.

## Included since v0.9.0
- feat: delete a ticket / work item from ZapDesk (#375)
- fix: post zap comment from WorkItemDetailDialog (#389)
- fix: show Customer Response on Question work item dialog (#400)
- fix: global search finds non-ticket work items by ID and text (#390)
- fix: allow LNURL callback host to differ from Lightning address host (#388)

Tag `v0.10.0` has been pushed and the production deploy has completed successfully.

## Test plan
N/A — version bump only (chore). No behavioural change; the only diff is the `version` field in `package.json`. The included features/fixes were each tested in their own PRs (#375, #389, #400, #390, #388).

🤖 Generated with [Claude Code](https://claude.com/claude-code)