### PR TITLE
feat: add Live update to Kanban board

### DIFF
--- a/src/app/kanban/page.tsx
+++ b/src/app/kanban/page.tsx
@@ -22,10 +22,12 @@ const STANDUP_CACHE_TTL_MS = 30 * 1000;
 const standupCache: Map<string, { data: StandupData; timestamp: number }> = new Map();
 const standupInFlight: Map<string, Promise<StandupData>> = new Map();
 
-// How often the "Live update" toggle polls for changes. Polling only runs
-// while the tab is visible (see visibilitychange handler) and an extra
-// fetch fires on tab-return so the board catches up immediately.
-const LIVE_UPDATE_INTERVAL_MS = 30 * 1000;
+// How often the "Live update" toggle polls for changes. Tied to the cache
+// TTL so the two stay in sync — every tick will bypass the cache (force
+// refresh) but the cadence still matches when data is considered fresh.
+// The interval is started/stopped based on visibility (see effect below),
+// and an extra fetch fires on tab-return so the board catches up.
+const LIVE_UPDATE_INTERVAL_MS = STANDUP_CACHE_TTL_MS;
 const LIVE_UPDATE_STORAGE_KEY = 'zapdesk:kanban:liveUpdate';
 
 function cacheKey(organization: string, currentSprintOnly: boolean): string {
@@ -118,6 +120,11 @@ function StandupPageContent() {
   const [liveUpdate, setLiveUpdate] = useState(false);
   const liveUpdateRef = useRef(liveUpdate);
   liveUpdateRef.current = liveUpdate;
+  // Tracks whether we've finished reading the persisted value from
+  // localStorage. The persist effect waits on this so its initial-mount run
+  // (with the default `false`) can't overwrite a stored `'true'` before the
+  // restore effect has had a chance to apply it.
+  const didHydrateRef = useRef(false);
 
   // Restore the user's last "Live update" choice on mount so they don't have
   // to re-enable it every visit. Done in an effect to keep SSR stable.
@@ -129,6 +136,7 @@ function StandupPageContent() {
     } catch {
       // localStorage may throw in private/sandboxed contexts — ignore
     }
+    didHydrateRef.current = true;
   }, []);
 
   // Detail dialog state — clicking a card fetches the full ticket and
@@ -168,8 +176,11 @@ function StandupPageContent() {
       setError(null);
 
       try {
-        // Dedupe concurrent requests for the same cache key
-        let promise = forceRefresh ? undefined : standupInFlight.get(key);
+        // Dedupe concurrent requests for the same cache key. forceRefresh
+        // bypasses the cache TTL above but still coalesces with any
+        // in-flight request so a tick + visibilitychange + mutation patch
+        // don't all double-hit the API simultaneously.
+        let promise = standupInFlight.get(key);
         if (!promise) {
           promise = (async () => {
             const params = new URLSearchParams();
@@ -217,34 +228,61 @@ function StandupPageContent() {
     }
   }, [session?.accessToken, hasOrganization, fetchStandupData]);
 
-  // Live update: poll while the tab is visible, pause when hidden, and
-  // refetch immediately when the tab comes back into focus so the board
-  // catches up without waiting for the next tick.
+  // Live update: while the tab is visible, run a poll on the cache TTL
+  // cadence. When the tab is hidden the interval is cleared so no timer
+  // is alive in the background. When the tab returns we trigger an
+  // immediate refetch and restart the interval, so the board catches up
+  // without waiting for the next tick.
   useEffect(() => {
     if (!liveUpdate) return;
 
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+
     const tick = () => {
-      if (liveUpdateRef.current && document.visibilityState === 'visible') {
+      if (liveUpdateRef.current) {
         fetchStandupData(true, true);
       }
     };
-    const interval = setInterval(tick, LIVE_UPDATE_INTERVAL_MS);
+
+    const startInterval = () => {
+      if (intervalId === null) {
+        intervalId = setInterval(tick, LIVE_UPDATE_INTERVAL_MS);
+      }
+    };
+
+    const stopInterval = () => {
+      if (intervalId !== null) {
+        clearInterval(intervalId);
+        intervalId = null;
+      }
+    };
 
     const onVisibilityChange = () => {
-      if (liveUpdateRef.current && document.visibilityState === 'visible') {
+      if (!liveUpdateRef.current) return;
+      if (document.visibilityState === 'visible') {
         fetchStandupData(true, true);
+        startInterval();
+      } else {
+        stopInterval();
       }
     };
+
+    if (document.visibilityState === 'visible') {
+      startInterval();
+    }
     document.addEventListener('visibilitychange', onVisibilityChange);
 
     return () => {
-      clearInterval(interval);
+      stopInterval();
       document.removeEventListener('visibilitychange', onVisibilityChange);
     };
   }, [liveUpdate, fetchStandupData]);
 
-  // Persist the toggle so it carries across page reloads
+  // Persist the toggle so it carries across page reloads. Skipped until
+  // after the restore effect has hydrated the value, so we don't briefly
+  // overwrite a stored `'true'` with the initial `false`.
   useEffect(() => {
+    if (!didHydrateRef.current) return;
     try {
       window.localStorage.setItem(LIVE_UPDATE_STORAGE_KEY, liveUpdate ? 'true' : 'false');
     } catch {

--- a/src/app/kanban/page.tsx
+++ b/src/app/kanban/page.tsx
@@ -552,7 +552,7 @@ function StandupPageContent() {
               <label
                 className="flex cursor-pointer items-center gap-2 text-xs"
                 style={{ color: 'var(--text-muted)' }}
-                title="Refresh the board automatically every 30 seconds while this tab is visible"
+                title={`Refresh the board automatically every ${Math.round(LIVE_UPDATE_INTERVAL_MS / 1000)} seconds while this tab is visible`}
               >
                 <input
                   type="checkbox"

--- a/src/app/kanban/page.tsx
+++ b/src/app/kanban/page.tsx
@@ -22,6 +22,12 @@ const STANDUP_CACHE_TTL_MS = 30 * 1000;
 const standupCache: Map<string, { data: StandupData; timestamp: number }> = new Map();
 const standupInFlight: Map<string, Promise<StandupData>> = new Map();
 
+// How often the "Live update" toggle polls for changes. Polling only runs
+// while the tab is visible (see visibilitychange handler) and an extra
+// fetch fires on tab-return so the board catches up immediately.
+const LIVE_UPDATE_INTERVAL_MS = 30 * 1000;
+const LIVE_UPDATE_STORAGE_KEY = 'zapdesk:kanban:liveUpdate';
+
 function cacheKey(organization: string, currentSprintOnly: boolean): string {
   return `${organization}::${currentSprintOnly ? 'sprint' : 'all'}`;
 }
@@ -109,9 +115,21 @@ function StandupPageContent() {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [autoRefresh, setAutoRefresh] = useState(false);
-  const autoRefreshRef = useRef(autoRefresh);
-  autoRefreshRef.current = autoRefresh;
+  const [liveUpdate, setLiveUpdate] = useState(false);
+  const liveUpdateRef = useRef(liveUpdate);
+  liveUpdateRef.current = liveUpdate;
+
+  // Restore the user's last "Live update" choice on mount so they don't have
+  // to re-enable it every visit. Done in an effect to keep SSR stable.
+  useEffect(() => {
+    try {
+      if (window.localStorage.getItem(LIVE_UPDATE_STORAGE_KEY) === 'true') {
+        setLiveUpdate(true);
+      }
+    } catch {
+      // localStorage may throw in private/sandboxed contexts — ignore
+    }
+  }, []);
 
   // Detail dialog state — clicking a card fetches the full ticket and
   // opens it in a dialog rather than navigating to the full page (#368).
@@ -199,15 +217,40 @@ function StandupPageContent() {
     }
   }, [session?.accessToken, hasOrganization, fetchStandupData]);
 
+  // Live update: poll while the tab is visible, pause when hidden, and
+  // refetch immediately when the tab comes back into focus so the board
+  // catches up without waiting for the next tick.
   useEffect(() => {
-    if (!autoRefresh) return;
-    const interval = setInterval(() => {
-      if (autoRefreshRef.current) {
+    if (!liveUpdate) return;
+
+    const tick = () => {
+      if (liveUpdateRef.current && document.visibilityState === 'visible') {
         fetchStandupData(true, true);
       }
-    }, 30000);
-    return () => clearInterval(interval);
-  }, [autoRefresh, fetchStandupData]);
+    };
+    const interval = setInterval(tick, LIVE_UPDATE_INTERVAL_MS);
+
+    const onVisibilityChange = () => {
+      if (liveUpdateRef.current && document.visibilityState === 'visible') {
+        fetchStandupData(true, true);
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [liveUpdate, fetchStandupData]);
+
+  // Persist the toggle so it carries across page reloads
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(LIVE_UPDATE_STORAGE_KEY, liveUpdate ? 'true' : 'false');
+    } catch {
+      // ignore — non-fatal
+    }
+  }, [liveUpdate]);
 
   // Generic state-change. Pass `project` when known to avoid an
   // expensive cross-project scan on the server.
@@ -467,18 +510,19 @@ function StandupPageContent() {
                 Current Sprint
               </label>
 
-              {/* Auto-refresh toggle */}
+              {/* Live update toggle */}
               <label
                 className="flex cursor-pointer items-center gap-2 text-xs"
                 style={{ color: 'var(--text-muted)' }}
+                title="Refresh the board automatically every 30 seconds while this tab is visible"
               >
                 <input
                   type="checkbox"
-                  checked={autoRefresh}
-                  onChange={(e) => setAutoRefresh(e.target.checked)}
+                  checked={liveUpdate}
+                  onChange={(e) => setLiveUpdate(e.target.checked)}
                   className="accent-[var(--primary)]"
                 />
-                Auto-refresh
+                Live update
               </label>
 
               {/* Manual refresh */}


### PR DESCRIPTION
## Summary
- Rename the existing "Auto-refresh" toggle on `/kanban` to **"Live update"**
- Make polling visibility-aware: the 30s tick only runs while `document.visibilityState === 'visible'`, so background tabs no longer hammer the DevOps API
- Refetch immediately on `visibilitychange` back to visible, so the board catches up without waiting for the next tick
- Persist the toggle in `localStorage` (`zapdesk:kanban:liveUpdate`) so users do not have to re-enable it every visit
- Added a hover tooltip on the toggle explaining the behaviour
<img width="1620" height="688" alt="image" src="https://github.com/user-attachments/assets/c2605d03-0546-4b09-93e5-c96abba13da6" />

Fixes #393

## Test plan
- [ ] Navigate to `/kanban`, confirm the toggle reads "Live update" and hovering shows the explanatory tooltip
- [ ] Tick **Live update**, then change a work item state in DevOps directly (or via another browser tab) — within ~30s the card moves to the matching column without a manual refresh
- [ ] With **Live update** on, switch to another tab/window for >30s; check the Network tab in DevTools and confirm no `/api/devops/standup` requests fire while hidden
- [ ] Switch back to the Kanban tab — a refetch fires immediately on focus return
- [ ] Toggle **Live update** on, reload the page — the toggle remains on (state restored from localStorage); toggle off and reload — it remains off
- [ ] Manual refresh button and Auto-refresh-while-disabled behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)