### PR TITLE
fix: restrict SLA Risk to ticket-eligible work item types

### DIFF
--- a/src/app/api/devops/sla-status/route.ts
+++ b/src/app/api/devops/sla-status/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { AzureDevOpsService } from '@/lib/devops';
 import { calculateSLAStatusForTickets, sortByUrgency, getSLASummary } from '@/lib/sla';
+import { TICKET_WORK_ITEM_TYPES } from '@/types';
 import type { SLAStatusResponse } from '@/types';
 
 export async function GET() {
@@ -14,7 +15,11 @@ export async function GET() {
     }
 
     const devopsService = new AzureDevOpsService(session.accessToken);
-    const tickets = await devopsService.getAllTickets();
+    // Restrict to the same work item types the Tickets view shows
+    // (Task, Enhancement, Issue, Bug, Risk, Question) so Epics/Features/
+    // User Stories tagged "ticket" don't inflate the SLA-breached count
+    // on the Home page. (issue #408)
+    const tickets = await devopsService.getAllTickets(true, TICKET_WORK_ITEM_TYPES);
 
     // Calculate SLA status for all active tickets
     const now = new Date();


### PR DESCRIPTION
## Summary
- `/api/devops/sla-status` was calling `getAllTickets()` without passing an `allowedTypes` filter, so any Epic, Feature, or User Story tagged "ticket" was counted as a breached/at-risk ticket on the Home page even though it never appeared in the Tickets view (which filters to `TICKET_WORK_ITEM_TYPES`)
- Pass `TICKET_WORK_ITEM_TYPES` (Task, Enhancement, Issue, Bug, Risk, Question) to `getAllTickets()` in the SLA endpoint so the SLA Risk panel and the Tickets view stay in sync

Fixes #408

## Test plan
- [x] Sign in and load the **Home** page
- [x] Compare the items under "Tickets Requiring Attention" against the **Tickets** view (`/tickets?view=all-active`)
- [x] Confirm every item on the SLA Risk list also appears in the Tickets view — no Epics, Features, or User Stories
- [x] Confirm the Breached / At Risk counts no longer include higher-level work item types
- [x] If a Task / Bug / Issue / Question / Enhancement / Risk tagged "ticket" is breached, it still appears (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)